### PR TITLE
admin: initialize context in phobos_admin_init()

### DIFF
--- a/src/admin/admin.c
+++ b/src/admin/admin.c
@@ -456,6 +456,10 @@ int phobos_admin_init(struct admin_handle *adm, bool lrs_required,
     union pho_comm_addr tlc_sock_addr;
     int rc;
 
+    rc = pho_context_init();
+    if (rc)
+        return rc;
+
     memset(adm, 0, sizeof(*adm));
     adm->phobosd_comm = pho_comm_info_init();
     adm->tlc_comm = pho_comm_info_init();


### PR DESCRIPTION
Issue: `phobos drive status` segfaults. Core dump:

```console
[root@elm-ent-dm01 var]# coredumpctl gdb 214418
           PID: 214418 (phobos)
           UID: 0 (root)
           GID: 0 (root)
        Signal: 11 (SEGV)
     Timestamp: Wed 2023-11-08 20:09:42 PST (1min 52s ago)
  Command Line: /usr/bin/python3 /usr/bin/phobos drive status
    Executable: /usr/bin/python3.9
 Control Group: /user.slice/user-0.slice/session-28.scope
          Unit: session-28.scope
         Slice: user-0.slice
       Session: 28
     Owner UID: 0 (root)
       Boot ID: dea53e0b4d11413998f2010226a42982
    Machine ID: 8b3448b534dd4fccb998f00e9977d41c
      Hostname: elm-ent-dm01
       Storage: /var/lib/systemd/coredump/core.phobos.0.dea53e0b4d11413998f2010226a42982.214418.1699502982000000.zst (present)
  Size on Disk: 2.4M
       Message: Process 214418 (phobos) of user 0 dumped core.
                
                Stack trace of thread 214418:
                #0  0x00007faee36878b4 pho_cfg_init_local (libphobos_admin.so.0 + 0x1b8b4)
                #1  0x00007faee3688a25 phobos_admin_init (libphobos_admin.so.0 + 0x1ca25)
                #2  0x00007faee36f58b6 ffi_call_unix64 (libffi.so.8 + 0x78b6)
                #3  0x00007faee36f2556 ffi_call_int.lto_priv.0 (libffi.so.8 + 0x4556)
                #4  0x00007faee370de5d _ctypes_callproc.cold (_ctypes.cpython-39-x86_64-linux-gnu.so + 0x8e5d)
                #5  0x00007faee370d742 PyCFuncPtr_call.cold (_ctypes.cpython-39-x86_64-linux-gnu.so + 0x8742)
                #6  0x00007faee4118694 _PyObject_MakeTpCall (libpython3.9.so.1.0 + 0x118694)
                #7  0x00007faee411558e _PyEval_EvalFrameDefault (libpython3.9.so.1.0 + 0x11558e)
                #8  0x00007faee411ce13 function_code_fastcall (libpython3.9.so.1.0 + 0x11ce13)
                #9  0x00007faee41105c3 _PyEval_EvalFrameDefault (libpython3.9.so.1.0 + 0x1105c3)
                #10 0x00007faee411ce13 function_code_fastcall (libpython3.9.so.1.0 + 0x11ce13)
                #11 0x00007faee4125372 method_vectorcall (libpython3.9.so.1.0 + 0x125372)
                #12 0x00007faee41129ed _PyEval_EvalFrameDefault (libpython3.9.so.1.0 + 0x1129ed)
                #13 0x00007faee411ce13 function_code_fastcall (libpython3.9.so.1.0 + 0x11ce13)
                #14 0x00007faee41252d1 method_vectorcall (libpython3.9.so.1.0 + 0x1252d1)
                #15 0x00007faee41102ee _PyEval_EvalFrameDefault (libpython3.9.so.1.0 + 0x1102ee)
                #16 0x00007faee411ce13 function_code_fastcall (libpython3.9.so.1.0 + 0x11ce13)
                #17 0x00007faee41105c3 _PyEval_EvalFrameDefault (libpython3.9.so.1.0 + 0x1105c3)
                #18 0x00007faee411ce13 function_code_fastcall (libpython3.9.so.1.0 + 0x11ce13)
                #19 0x00007faee41102ee _PyEval_EvalFrameDefault (libpython3.9.so.1.0 + 0x1102ee)
                #20 0x00007faee410eeb5 _PyEval_EvalCode (libpython3.9.so.1.0 + 0x10eeb5)
                #21 0x00007faee4189805 _PyEval_EvalCodeWithName (libpython3.9.so.1.0 + 0x189805)
                #22 0x00007faee418979d PyEval_EvalCodeEx (libpython3.9.so.1.0 + 0x18979d)
                #23 0x00007faee418974f PyEval_EvalCode (libpython3.9.so.1.0 + 0x18974f)
                #24 0x00007faee41b9884 run_eval_code_obj (libpython3.9.so.1.0 + 0x1b9884)
                #25 0x00007faee41b56e6 run_mod (libpython3.9.so.1.0 + 0x1b56e6)
                #26 0x00007faee408ad65 pyrun_file.cold (libpython3.9.so.1.0 + 0x8ad65)
                #27 0x00007faee41af433 PyRun_SimpleFileExFlags (libpython3.9.so.1.0 + 0x1af433)
                #28 0x00007faee41abc98 Py_RunMain (libpython3.9.so.1.0 + 0x1abc98)
                #29 0x00007faee417c13d Py_BytesMain (libpython3.9.so.1.0 + 0x17c13d)
                #30 0x00007faee3c3feb0 __libc_start_call_main (libc.so.6 + 0x3feb0)
                #31 0x00007faee3c3ff60 __libc_start_main@@GLIBC_2.34 (libc.so.6 + 0x3ff60)
                #32 0x000056426c4a9095 _start (python3.9 + 0x1095)
                ELF object binary architecture: AMD x86-64

GNU gdb (GDB) Red Hat Enterprise Linux 10.2-10.el9
Copyright (C) 2021 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-redhat-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from /usr/bin/python3.9...
Reading symbols from .gnu_debugdata for /usr/bin/python3.9...
(No debugging symbols found in .gnu_debugdata for /usr/bin/python3.9)
[New LWP 214418]

warning: Section `.reg-xstate/214418' in core file too small.
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
Core was generated by `/usr/bin/python3 /usr/bin/phobos drive status'.
Program terminated with signal SIGSEGV, Segmentation fault.

warning: Section `.reg-xstate/214418' in core file too small.
#0  0x00007faee36878b4 in pho_cfg_init_local (config_file=config_file@entry=0x0) at ../cfg/cfg.c:107
107	    if (config_is_loaded())
Missing separate debuginfos, use: dnf debuginfo-install python3-3.9.16-1.el9_2.1.x86_64
(gdb) bt
#0  0x00007faee36878b4 in pho_cfg_init_local (config_file=config_file@entry=0x0) at ../cfg/cfg.c:107
#1  0x00007faee3688a25 in phobos_admin_init (adm=0x7faee27f7030, lrs_required=<optimized out>, tlc_required=<optimized out>) at /usr/src/debug/phobos-1.95-2.el9.x86_64/src/admin/admin.c:463
#2  0x00007faee36f58b6 in ffi_call_unix64 () from /lib64/libffi.so.8
#3  0x00007faee36f2556 in ffi_call_int.lto_priv () from /lib64/libffi.so.8
#4  0x00007faee370de5d in _ctypes_callproc.cold () from /usr/lib64/python3.9/lib-dynload/_ctypes.cpython-39-x86_64-linux-gnu.so
#5  0x00007faee370d742 in PyCFuncPtr_call.cold () from /usr/lib64/python3.9/lib-dynload/_ctypes.cpython-39-x86_64-linux-gnu.so
#6  0x00007faee4118694 in _PyObject_MakeTpCall () from /lib64/libpython3.9.so.1.0
#7  0x00007faee411558e in _PyEval_EvalFrameDefault () from /lib64/libpython3.9.so.1.0
#8  0x00007faee411ce13 in function_code_fastcall () from /lib64/libpython3.9.so.1.0
#9  0x00007faee41105c3 in _PyEval_EvalFrameDefault () from /lib64/libpython3.9.so.1.0
#10 0x00007faee411ce13 in function_code_fastcall () from /lib64/libpython3.9.so.1.0
#11 0x00007faee4125372 in method_vectorcall () from /lib64/libpython3.9.so.1.0
#12 0x00007faee41129ed in _PyEval_EvalFrameDefault () from /lib64/libpython3.9.so.1.0
#13 0x00007faee411ce13 in function_code_fastcall () from /lib64/libpython3.9.so.1.0
#14 0x00007faee41252d1 in method_vectorcall () from /lib64/libpython3.9.so.1.0
#15 0x00007faee41102ee in _PyEval_EvalFrameDefault () from /lib64/libpython3.9.so.1.0
#16 0x00007faee411ce13 in function_code_fastcall () from /lib64/libpython3.9.so.1.0
#17 0x00007faee41105c3 in _PyEval_EvalFrameDefault () from /lib64/libpython3.9.so.1.0
#18 0x00007faee411ce13 in function_code_fastcall () from /lib64/libpython3.9.so.1.0
#19 0x00007faee41102ee in _PyEval_EvalFrameDefault () from /lib64/libpython3.9.so.1.0
#20 0x00007faee410eeb5 in _PyEval_EvalCode () from /lib64/libpython3.9.so.1.0
#21 0x00007faee4189805 in _PyEval_EvalCodeWithName () from /lib64/libpython3.9.so.1.0
#22 0x00007faee418979d in PyEval_EvalCodeEx () from /lib64/libpython3.9.so.1.0
#23 0x00007faee418974f in PyEval_EvalCode () from /lib64/libpython3.9.so.1.0
#24 0x00007faee41b9884 in run_eval_code_obj () from /lib64/libpython3.9.so.1.0
#25 0x00007faee41b56e6 in run_mod () from /lib64/libpython3.9.so.1.0
#26 0x00007faee408ad65 in pyrun_file.cold () from /lib64/libpython3.9.so.1.0
#27 0x00007faee41af433 in PyRun_SimpleFileExFlags () from /lib64/libpython3.9.so.1.0
#28 0x00007faee41abc98 in Py_RunMain () from /lib64/libpython3.9.so.1.0
#29 0x00007faee417c13d in Py_BytesMain () from /lib64/libpython3.9.so.1.0
#30 0x00007faee3c3feb0 in __libc_start_call_main () from /lib64/libc.so.6
#31 0x00007faee3c3ff60 in __libc_start_main_impl () from /lib64/libc.so.6
#32 0x000056426c4a9095 in _start ()
(gdb) l
102	 */
103	int pho_cfg_init_local(const char *config_file)
104	{
105	    const char *cfg = config_file;
106	
107	    if (config_is_loaded())
108	        return -EALREADY;
109	
110	    if (cfg == NULL)
111	        cfg = getenv("PHOBOS_CFG_FILE");
(gdb) p config_file
$1 = 0x0
```