### PR TITLE
rpm: add pho_ldm.h to installed files

### DIFF
--- a/phobos.spec.in
+++ b/phobos.spec.in
@@ -168,6 +168,7 @@ echo "%{_libdir}/phobos" > %{buildroot}/%{_sysconfdir}/ld.so.conf.d/phobos.conf
 %{_includedir}/pho_comm.h
 %{_includedir}/pho_common.h
 %{_includedir}/pho_dss.h
+%{_includedir}/pho_ldm.h
 %{_includedir}/pho_types.h
 %{_includedir}/phobos_store.h
 %{_includedir}/phobos_admin.h

--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -13,7 +13,7 @@ noinst_HEADERS=pho_cfg.h pho_comm.h pho_common.h pho_daemon.h pho_dss.h \
 #   - phobos_admin.h  admin command interface
 #   - pho_attrs.h     access and manipulate object metadata
 include_HEADERS=pho_attrs.h pho_cfg.h pho_comm.h pho_common.h pho_dss.h \
-                pho_types.h phobos_store.h phobos_admin.h
+                pho_ldm.h pho_types.h phobos_store.h phobos_admin.h
 
 $(proto_headers): $(protodir)/gen-proto.stamp
 


### PR DESCRIPTION
To fix the following problem when compiling lustre-hsm-phobos against phobos 1.95.1:
```
In file included from ../src/hints.c:4:
/usr/include/phobos_admin.h:32:10: fatal error: pho_ldm.h: No such file or directory
   32 | #include "pho_ldm.h"
      |          ^~~~~~~~~~~
```