### PR TITLE
phobosdb: use bigint for size

### DIFF
--- a/src/cli/phobos/db/__init__.py
+++ b/src/cli/phobos/db/__init__.py
@@ -426,7 +426,7 @@ class Migrator:
             CREATE TABLE extent (
                 extent_uuid     varchar(36) UNIQUE DEFAULT uuid_generate_v4(),
                 state           extent_state,
-                size            integer,
+                size            bigint,
                 medium_family   dev_family,
                 medium_id       varchar(255),
                 address         varchar(1024),
@@ -444,7 +444,7 @@ class Migrator:
                                 object_uuid, object_version, lyt_index)
                 SELECT uuid_generate_v4(),
                        state,
-                       cast(value->>'sz' AS integer),
+                       cast(value->>'sz' AS bigint),
                        cast(value->>'fam' AS dev_family),
                        value->>'media',
                        value->>'addr',


### PR DESCRIPTION
NumericValueOutOfRange exception when doing phobosdb migrate

Trying master branch today (f4eb7cc61b4c96249e4a6de56a5762f1211a92dc), migrating the DB from 1.95.1 fails with the following errors:

```
[root@elm-ent-dm02 ~]# phobos_db migrate
You are about to upgrade database schema from version 1.95 to version 2.0.
Do you want to continue? [y/N]: y
Traceback (most recent call last):
  File "/usr/lib64/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib64/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/usr/lib64/python3.9/site-packages/phobos/db/__main__.py", line 233, in <module>
    main()
  File "/usr/lib64/python3.9/site-packages/phobos/db/__main__.py", line 228, in main
    args.main(args, migrator)
  File "/usr/lib64/python3.9/site-packages/phobos/db/__main__.py", line 74, in migrate
    migrator.migrate(args.target_version)
  File "/usr/lib64/python3.9/site-packages/phobos/db/__init__.py", line 580, in migrate
    converter()
  File "/usr/lib64/python3.9/site-packages/phobos/db/__init__.py", line 545, in convert_1_95_to_2_0
    self.convert_schema_1_95_to_2_0()
  File "/usr/lib64/python3.9/site-packages/phobos/db/__init__.py", line 376, in convert_schema_1_95_to_2_0
    cur.execute("""
psycopg2.errors.NumericValueOutOfRange: value "108051431424" is out of range for type integer
```
