### PR TITLE
lrs_sched: remove unused goto label

### DIFF
--- a/src/lrs/lrs_sched.c
+++ b/src/lrs/lrs_sched.c
@@ -1940,7 +1940,6 @@ static int sched_handle_write_alloc(struct lrs_sched *sched,
             break;
     }
 
-end:
     return publish_or_cancel(sched, reqc, rc, next_medium_index);
 }
 


### PR DESCRIPTION
This emits a warning (which fails build) with newer versions of gcc:

lrs_sched.c: In function ‘sched_handle_write_alloc’: lrs_sched.c:1936:1: error: label ‘end’ defined but not used [-Werror=unused-label]
 1936 | end:
      | ^~~

Change-Id: I875817ad93ab33732a1b6ab9bcf344c682998059