### PR TITLE
cli: fix 'load_file' error message

### DIFF
--- a/src/cli/phobos/core/cfg.py
+++ b/src/cli/phobos/core/cfg.py
@@ -34,8 +34,7 @@ def load_file(path=None):
     ret = LIBPHOBOS.pho_cfg_init_local(path.encode('utf-8') if path else None)
     ret = abs(ret)
     if ret not in (0, errno.EALREADY):
-        raise IOError(ret, "Failed to load configuration file '%s': %d" %
-                      (path, os.strerror(ret)))
+        raise IOError(ret, "Phobos config init failed: %s" % os.strerror(ret))
 
 
 # Singleton to differenciate cases where default was not provided and


### PR DESCRIPTION
- phobos would fail while building the error because of the bad format specifier: raise IOError(ret, "Failed to load configuration file '%s': %d" % TypeError: %d format: a number is required, not str

- Fixing that, the path here is most likely None, leading to somewhat weird message: PermissionError: [Errno 13] Failed to load configuration file 'None': Permission denied

So also remove path from message; phobos already logs the error to stdout anyway so this is redundant, it might make more sense to not print anything at all and just call sys.exit()?

Here's full command output on error as of this patch:
```
2024-01-20 21:48:46.919892000 <ERROR> failed to read configuration file '/etc/phobos.conf': Permission denied (13)

Traceback (most recent call last):
  File "/usr/bin/phobos", line 30, in <module>
    phobos_main()
  File "/usr/lib64/python3.9/site-packages/phobos/cli.py", line 2309, in phobos_main
    with PhobosActionContext(args if args is not None else sys.argv[1::]) \
  File "/usr/lib64/python3.9/site-packages/phobos/cli.py", line 2169, in __init__
    self.load_config()
  File "/usr/lib64/python3.9/site-packages/phobos/cli.py", line 2211, in load_config
    cfg.load_file(cpath)
  File "/usr/lib64/python3.9/site-packages/phobos/core/cfg.py", line 37, in load_file
    raise IOError(ret, "Phobos config init failed: %s" % os.strerror(ret))
PermissionError: [Errno 13] Phobos config init failed: Permission denied
```

Change-Id: I393be43be1e317bfda8dd373c24916493c81ef84