### PR TITLE
TLC: add a listen_interface setting

### DIFF
--- a/doc/cfg/template.conf
+++ b/doc/cfg/template.conf
@@ -217,6 +217,8 @@ port = 20123
 # and port.
 #listen_hostname = 0.0.0.0
 #listen_port = 20123
+# It's also possible to force listening to a given interface
+#listen_interface = admin0
 
 # path to library changer for the server
 lib_device = /dev/changer

--- a/src/communication/comm.c
+++ b/src/communication/comm.c
@@ -33,6 +33,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <netdb.h>
+#include <net/if.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -359,6 +360,28 @@ out_err:
     return rc;
 }
 
+static int tcp_set_socket_listen_interface(int socket_fd,
+                                           const union pho_comm_addr *addr)
+{
+    int rc;
+    struct ifreq interface;
+
+    if (!addr->tcp.interface)
+        return 0;
+
+    rc = snprintf(interface.ifr_name, IFNAMSIZ, "%s", addr->tcp.interface);
+    if (rc >= IFNAMSIZ)
+        LOG_RETURN(-ERANGE, "Interface name '%s' does not fit in %d bytes",
+                   addr->tcp.interface, IFNAMSIZ);
+
+    rc = setsockopt(socket_fd, SOL_SOCKET, SO_BINDTODEVICE, &interface,
+                    sizeof(interface));
+    if (rc < 0)
+        LOG_RETURN(-errno, "Could not bind socket to interface '%s'",
+                   addr->tcp.interface);
+    return 0;
+}
+
 int pho_comm_open(struct pho_comm_info *ci, const union pho_comm_addr *addr,
                   enum pho_comm_socket_type type)
 {
@@ -426,6 +449,9 @@ int pho_comm_open(struct pho_comm_info *ci, const union pho_comm_addr *addr,
         freeaddrinfo(addr_res);
         addr_res = NULL;
     }
+
+    /* ignore errors */
+    tcp_set_socket_listen_interface(ci->socket_fd, addr);
 
     if (listen(ci->socket_fd, n_max_listen))
         LOG_GOTO(out_err, rc = -errno, "Socket listening failed");

--- a/src/communication/comm.c
+++ b/src/communication/comm.c
@@ -198,6 +198,27 @@ out:
     return rc;
 }
 
+int tlc_listen_interface_from_cfg(const char *library,
+                                 const char **tlc_listen_interface)
+{
+    char *section_name;
+    int rc;
+
+    rc = asprintf(&section_name, TLC_SECTION_CFG, library);
+    if (rc < 0)
+        return -ENOMEM;
+
+    rc = pho_cfg_get_val(section_name, TLC_LISTEN_INTERFACE_CFG_PARAM,
+                         tlc_listen_interface);
+    if (rc == -ENODATA) {
+        *tlc_listen_interface = DEFAULT_TLC_LISTEN_INTERFACE;
+        rc = 0;
+    }
+
+    free(section_name);
+    return rc;
+}
+
 int tlc_lib_device_from_cfg(const char *library, const char **tlc_lib_device)
 {
     char *section_name;

--- a/src/include/pho_comm.h
+++ b/src/include/pho_comm.h
@@ -45,11 +45,13 @@
 #define DEFAULT_TLC_HOSTNAME "localhost"
 #define TLC_PORT_CFG_PARAM "port"
 #define DEFAULT_TLC_PORT 20123
+#define DEFAULT_TLC_LISTEN_INTERFACE NULL
 /* listen_hostname/hostname and port are failover settings:
  * if listen_hostname is not set, hostame is used
  */
 #define TLC_LISTEN_HOSTNAME_CFG_PARAM "listen_hostname"
 #define TLC_LISTEN_PORT_CFG_PARAM "listen_port"
+#define TLC_LISTEN_INTERFACE_CFG_PARAM "listen_interface"
 #define TLC_LIB_DEVICE_CFG_PARAM "lib_device"
 #define DEFAULT_TLC_LIB_DEVICE "/dev/changer"
 
@@ -183,6 +185,17 @@ int tlc_port_from_cfg(const char *library, int *tlc_port);
  * \return                      0 on success, negative POSIX error on failure
  */
 int tlc_listen_port_from_cfg(const char *library, int *tlc_listen_port);
+
+/**
+ * Get tlc listen interface from config
+ *
+ * \param[in]       library             Targeted library
+ * \param[out]      tlc_listen_interface     TLC listen interface
+ *
+ * \return                      0 on success, negative POSIX error on failure
+ */
+int tlc_listen_interface_from_cfg(const char *library,
+                                  const char **tlc_listen_interface);
 
 /**
  * Get TLC library device from config

--- a/src/include/pho_comm.h
+++ b/src/include/pho_comm.h
@@ -63,6 +63,7 @@ union pho_comm_addr {
     struct {
         const char *hostname;
         int port;
+        const char *interface;
     } tcp;
 };
 

--- a/src/tlc/tlc.c
+++ b/src/tlc/tlc.c
@@ -122,6 +122,13 @@ static int tlc_init(struct tlc *tlc, const char *library)
                  "Unable to get TLC listen port from config for library %s",
                  tlc->lib.name);
 
+    rc = tlc_listen_interface_from_cfg(tlc->lib.name,
+                                       &sock_addr.tcp.interface);
+    if (rc)
+        LOG_GOTO(close_lib, rc,
+                 "Unable to get TLC listen interface from config for library %s",
+                 tlc->lib.name);
+
     rc = pho_comm_open(&tlc->comm, &sock_addr, PHO_COMM_TCP_SERVER);
     if (rc)
         LOG_GOTO(close_lib, rc, "Error while opening the TLC socket");


### PR DESCRIPTION
see individual patches for detail:

It can be useful to bind a listening socket to an interface, so 0.0.0.0
can be used in order to allow connections on an IP address that is not yet
configured (e.g. virtual IP), but still limit inbound connections from a
single interface without filtering at firewall level.

This adds a new field to struct pho_comm_addr's tcp struct so that if an
interface is set we use it.

setsockopt SO_BINDTODEVICE requires NET_ADMIN so this call might fail:
this patch ignores the error on purpose so the server still starts,
but a log is emitted for diagnostic.

-----
Add a config item to allow binding the tlc server to an interface

This can easily be tested by setting listen_interface to an existing
interface and trying to connect via either 127.0.0.1 or that interface's
IP: only using the IP of the interface will work.
