### PR TITLE
lrs: add a max write per grouping to fifo scheduler

### DIFF
--- a/doc/cfg/template.conf
+++ b/doc/cfg/template.conf
@@ -28,9 +28,8 @@ sync_nb_req = tape=5,dir=5
 sync_wsize_kb = tape=1048576,dir=1048576
 
 # Fifo maximum number of concurrent write operation per grouping per scheduler,
-# positive value, set to zero if negative
+# positive value to limit concurrent writes, or 0 for no limit
 # (this parameter is only used by the fifo write schedulers)
-# (0 is the default and means no limit)
 fifo_max_write_per_grouping = 0
 
 # I/O scheduling algorithms for dir family

--- a/doc/cfg/template.conf
+++ b/doc/cfg/template.conf
@@ -27,6 +27,12 @@ sync_nb_req = tape=5,dir=5
 # positive value, greater than 0 and lesser or equal than 2^54
 sync_wsize_kb = tape=1048576,dir=1048576
 
+# Fifo maximum number of concurrent write operation per grouping per scheduler,
+# positive value, set to zero if negative
+# (this parameter is only used by the fifo write schedulers)
+# (0 is the default and means no limit)
+fifo_max_write_per_grouping = 0
+
 # I/O scheduling algorithms for dir family
 [io_sched_dir]
 # Scheduling algorithm used for read requests

--- a/phobos.spec.in
+++ b/phobos.spec.in
@@ -27,7 +27,8 @@ Source0: %{name}-%{version}.tar.gz
 %endif
 
 BuildRequires: %{postgres_prefix}-devel
-BuildRequires: glib2-devel >= 2.28
+# g_ptr_array_find needs glib2 2.54
+BuildRequires: glib2-devel >= 2.54
 BuildRequires: %{python_prefix}-devel
 BuildRequires: jansson-devel >= 2.5
 BuildRequires: libattr-devel
@@ -48,7 +49,7 @@ BuildRequires: python3-argcomplete
 
 Requires: %{postgres_prefix}-server
 Requires: %{postgres_prefix}-contrib
-Requires: glib2 >= 2.28
+Requires: glib2 >= 2.54
 Requires: jansson
 Requires: libini_config
 Requires: openssl
@@ -81,7 +82,7 @@ in a SCSI library and local directories.
 Summary: C API for Phobos Object Store.
 
 Requires: phobos
-Requires: glib2-devel >= 2.28
+Requires: glib2-devel >= 2.54
 Requires: jansson-devel >= 2.5
 Requires: libattr-devel
 

--- a/src/lrs/io_schedulers/fifo.c
+++ b/src/lrs/io_schedulers/fifo.c
@@ -185,7 +185,7 @@ static bool current_write_per_grouping_greater_than_max(GPtrArray *devices,
 
         dev = g_ptr_array_index(devices, i);
         MUTEX_LOCK(&dev->ld_mutex);
-        if ((dev && dev->ld_sub_request &&
+        if ((dev->ld_sub_request &&
              pho_request_is_write(dev->ld_sub_request->reqc->req) &&
              dev->ld_sub_request->reqc->req->walloc->grouping &&
              !strcmp(dev->ld_sub_request->reqc->req->walloc->grouping,
@@ -193,7 +193,7 @@ static bool current_write_per_grouping_greater_than_max(GPtrArray *devices,
              !g_array_binary_search(socket_id_array,
                                     &dev->ld_sub_request->reqc->socket_id,
                                     g_cmp_int, NULL)) ||
-            (dev && dev->ld_ongoing_io && dev->ld_ongoing_grouping.grouping &&
+            (dev->ld_ongoing_io && dev->ld_ongoing_grouping.grouping &&
              !strcmp(dev->ld_ongoing_grouping.grouping, grouping) &&
              !g_array_binary_search(socket_id_array,
                                     &dev->ld_ongoing_grouping.socket_id,
@@ -226,8 +226,8 @@ static int fifo_limited_grouping_peek_request(struct io_scheduler *io_sched,
     GQueue *requeued_elem = g_queue_new();
     struct queue_element *elem;
 
-    elem = g_queue_peek_tail(queue);
 new_elem:
+    elem = g_queue_peek_tail(queue);
     if (!elem) {
         *reqc = NULL;
         goto requeue;
@@ -238,7 +238,6 @@ new_elem:
         current_write_per_grouping_greater_than_max(io_sched->devices,
             elem->reqc->req->walloc->grouping, max_write_per_grouping())) {
         g_queue_push_head(requeued_elem, g_queue_pop_tail(queue));
-        elem = g_queue_peek_tail(queue);
         goto new_elem;
     }
 

--- a/src/lrs/lrs.c
+++ b/src/lrs/lrs.c
@@ -233,6 +233,11 @@ static void notify_device_request_is_canceled(struct resp_container *respc)
     for (i = 0; i < respc->devices_len; i++) {
         MUTEX_LOCK(&respc->devices[i]->ld_mutex);
         respc->devices[i]->ld_ongoing_io = false;
+        if (respc->devices[i]->ld_ongoing_grouping.grouping) {
+            free(respc->devices[i]->ld_ongoing_grouping.grouping);
+            respc->devices[i]->ld_ongoing_grouping.grouping = NULL;
+        }
+
         MUTEX_UNLOCK(&respc->devices[i]->ld_mutex);
     }
 }
@@ -523,6 +528,10 @@ static int release_medium(struct lrs_sched *sched,
 
     /* Acknowledgement of the request */
     dev->ld_ongoing_io = false;
+    if (dev->ld_ongoing_grouping.grouping) {
+        free(dev->ld_ongoing_grouping.grouping);
+        dev->ld_ongoing_grouping.grouping = NULL;
+    }
 
     MUTEX_UNLOCK(&dev->ld_mutex);
 

--- a/src/lrs/lrs_cfg.c
+++ b/src/lrs/lrs_cfg.c
@@ -79,6 +79,11 @@ const struct pho_config_item cfg_lrs[] = {
         .name    = "max_health",
         .value   = "1",
     },
+    [PHO_CFG_LRS_fifo_max_write_per_grouping] = {
+        .section = "lrs",
+        .name    = "fifo_max_write_per_grouping",
+        .value   = "0",
+    },
 };
 
 static int _get_unsigned_long_from_string(const char *value,

--- a/src/lrs/lrs_cfg.h
+++ b/src/lrs/lrs_cfg.h
@@ -42,8 +42,9 @@ enum pho_cfg_params_lrs {
     PHO_CFG_LRS_sync_nb_req,
     PHO_CFG_LRS_sync_wsize_kb,
     PHO_CFG_LRS_max_health,
+    PHO_CFG_LRS_fifo_max_write_per_grouping,
 
-    PHO_CFG_LRS_LAST = PHO_CFG_LRS_max_health,
+    PHO_CFG_LRS_LAST = PHO_CFG_LRS_fifo_max_write_per_grouping,
 };
 
 extern const struct pho_config_item cfg_lrs[];

--- a/src/lrs/lrs_device.c
+++ b/src/lrs/lrs_device.c
@@ -1801,7 +1801,8 @@ out_free:
     if (!io_ended && !sub_request_requeued) {
         dev->ld_ongoing_io = true;
         if (grouping) {
-            dev->ld_ongoing_grouping.grouping = xstrdup(grouping);
+            dev->ld_ongoing_grouping.grouping = grouping;
+            grouping = NULL;
             dev->ld_ongoing_grouping.socket_id = socket_id;
         }
     }

--- a/src/lrs/lrs_device.c
+++ b/src/lrs/lrs_device.c
@@ -579,8 +579,18 @@ static void clean_tosync_array(struct lrs_dev *dev, int rc)
                 /* If it is a partial request, it means that the client has not
                  * finished writing
                  */
-                if (req->reqc->req->release->partial)
+                if (req->reqc->req->release->partial) {
+                    pho_req_release_elt_t *media =
+                        req->reqc->req->release->media[req->medium_index];
+                    const char *grouping = media->grouping;
+
                     dev->ld_ongoing_io = true;
+                    if (grouping) {
+                        dev->ld_ongoing_grouping.grouping = xstrdup(grouping);
+                        dev->ld_ongoing_grouping.socket_id =
+                            req->reqc->socket_id;
+                    }
+                }
             }
         } else {
             req->reqc = NULL;   /* only the last device free reqc */
@@ -1733,9 +1743,11 @@ static int dev_handle_read_write(struct lrs_dev *dev)
     struct medium_switch_context context = {0};
     struct media_info *medium_to_alloc;
     bool sub_request_requeued = false;
+    char *grouping = NULL;
     bool io_ended = false;
     bool cancel = false;
     bool locked = false;
+    int socket_id = 0;
     int rc = 0;
 
     ENTRY;
@@ -1743,6 +1755,13 @@ static int dev_handle_read_write(struct lrs_dev *dev)
     if (cancel_subrequest_on_error(sub_request)) {
         io_ended = true;
         goto out_free;
+    }
+
+    /* saving grouping id */
+    if (pho_request_is_write(dev->ld_sub_request->reqc->req) &&
+        dev->ld_sub_request->reqc->req->walloc->grouping) {
+            grouping = xstrdup(dev->ld_sub_request->reqc->req->walloc->grouping);
+            socket_id = dev->ld_sub_request->reqc->socket_id;
     }
 
     medium_to_alloc =
@@ -1779,8 +1798,15 @@ out_free:
     if (!locked)
         MUTEX_LOCK(&dev->ld_mutex);
 
-    if (!io_ended && !sub_request_requeued)
+    if (!io_ended && !sub_request_requeued) {
         dev->ld_ongoing_io = true;
+        if (grouping) {
+            dev->ld_ongoing_grouping.grouping = xstrdup(grouping);
+            dev->ld_ongoing_grouping.socket_id = socket_id;
+        }
+    }
+
+    free(grouping);
 
     dev->ld_sub_request = NULL;
     if (!sub_request_requeued) {
@@ -2059,6 +2085,12 @@ static void dev_thread_end(struct lrs_dev *device)
         dev_cleanup_on_error(device);
 
     device->ld_ongoing_io = false;
+    if (device->ld_ongoing_grouping.grouping) {
+        free(device->ld_ongoing_grouping.grouping);
+        device->ld_ongoing_grouping.grouping = NULL;
+    }
+
+    MUTEX_UNLOCK(&device->ld_mutex);
 }
 
 static int dev_perform_sync(struct lrs_dev *device, struct thread_info *thread)

--- a/src/lrs/lrs_device.h
+++ b/src/lrs/lrs_device.h
@@ -190,6 +190,11 @@ struct sync_params {
                                      */
 };
 
+struct ongoing_grouping {
+    char *grouping;  /**< NULL if no ongoing grouping */
+    int socket_id;   /**< Socket id of the ongoing grouping */
+};
+
 /**
  * Data specific to the device thread.
  *
@@ -258,6 +263,7 @@ struct lrs_dev {
                                                   *  scheduled
                                                   */
     bool                 ld_ongoing_io;         /**< one I/O is ongoing */
+    struct ongoing_grouping ld_ongoing_grouping; /**< track on going grouping */
     bool                 ld_needs_sync;         /**< medium needs to be sync */
     struct thread_info   ld_device_thread;      /**< thread handling the actions
                                                   * executed on the device

--- a/src/lrs/lrs_sched.c
+++ b/src/lrs/lrs_sched.c
@@ -2658,6 +2658,11 @@ void rwalloc_cancel_DONE_devices(struct req_container *reqc)
             MUTEX_LOCK(&respc->devices[i]->ld_mutex);
             reqc->params.rwalloc.media[i].status = SUB_REQUEST_CANCEL;
             respc->devices[i]->ld_ongoing_io = false;
+            if (respc->devices[i]->ld_ongoing_grouping.grouping) {
+                free(respc->devices[i]->ld_ongoing_grouping.grouping);
+                respc->devices[i]->ld_ongoing_grouping.grouping = NULL;
+            }
+
             MUTEX_UNLOCK(&respc->devices[i]->ld_mutex);
             respc->devices[i] = NULL;
             if (is_write) {

--- a/tests/externs/cli/Makefile.am
+++ b/tests/externs/cli/Makefile.am
@@ -55,6 +55,7 @@ check_SCRIPTS=acceptance.test \
               test_drive_scsi_release.test \
               test_extent_list.test \
               test_fair_share.test \
+              test_fifo_max_write_per_grouping.test \
               test_file_after_put.test \
               test_format.test \
               test_get.test \

--- a/tests/externs/cli/test_fifo_max_write_per_grouping.test
+++ b/tests/externs/cli/test_fifo_max_write_per_grouping.test
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+#
+#  All rights reserved (c) 2014-2025 CEA/DAM.
+#
+#  This file is part of Phobos.
+#
+#  Phobos is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation, either version 2.1 of the Licence, or
+#  (at your option) any later version.
+#
+#  Phobos is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Phobos. If not, see <http://www.gnu.org/licenses/>.
+#
+
+#
+# Integration test for put --grouping command
+#
+
+test_dir=$(dirname $(readlink -e $0))
+. $test_dir/test_env.sh
+. $test_dir/setup_db.sh
+. $test_dir/test_launch_daemon.sh
+. $test_dir/tape_drive.sh
+. $test_dir/utils.sh
+. $test_dir/utils_generation.sh
+
+function setup()
+{
+    setup_tables
+    if [[ -w /dev/changer ]]; then
+        invoke_daemons
+    else
+        invoke_lrs
+    fi
+
+    setup_test_dirs
+    setup_dummy_files 3 1k 1
+    DIRS=()
+    for i in `seq 0 2`; do
+        DIRS+=($(mktemp -d ${DIR_TEST}/dir_XXXX))
+        $phobos dir add ${DIRS[$i]}
+        $phobos dir format --unlock ${DIRS[$i]}
+    done
+}
+
+function cleanup() {
+    if [[ -w /dev/changer ]]; then
+        waive_daemons
+        drain_all_drives
+    else
+        waive_lrs
+    fi
+
+    drop_tables
+    cleanup_dummy_files
+    cleanup_test_dirs
+}
+
+function phobos_delayed_dev_release()
+{
+    (
+        tmp_gdb_script=$(mktemp)
+        trap "rm $tmp_gdb_script" EXIT
+        cat <<EOF > "$tmp_gdb_script"
+set breakpoint pending on
+break raid_writer_split_setup
+commands
+shell sleep 1
+continue
+end
+run $phobos $*
+EOF
+
+        DEBUGINFOD_URLS="" gdb -batch -x "$tmp_gdb_script" -q python3
+    )
+}
+
+function put_check_grouping() {
+    local dir_tape=$1
+    local g_limit=$2
+
+    waive_lrs
+    export PHOBOS_LRS_fifo_max_write_per_grouping="${g_limit}"
+    invoke_lrs
+
+    PIDS=()
+    for i in `seq 0 2`; do
+        phobos_delayed_dev_release put -f ${dir_tape} --grouping my_group \
+            ${FILES[$i]} ${FILES[$i]}_${g_limit} &
+        PIDS+=( $! )
+    done
+
+    for i in `seq 0 2`; do
+        wait ${PIDS[$i]} ||
+            exit_error "Some put failed on dir with grouping limited to" \
+                       "${g_limit}"
+    done
+
+    nb_g_dir=$($phobos ${dir_tape} list -o groupings | grep my_group | wc -l)
+    if (( nb_g_dir != g_limit )) ; then
+        exit_error "${nb_g_dir} ${dir_tape} instead of ${g_limit} limited"
+    fi
+
+}
+
+function test_max_grouping_dir() {
+    DIRS=()
+    for i in `seq 0 2`; do
+        DIRS+=($(mktemp -d ${DIR_TEST}/dir_XXXX))
+        $phobos dir add ${DIRS[$i]}
+        $phobos dir format --unlock ${DIRS[$i]}
+    done
+
+    put_check_grouping dir 1
+    put_check_grouping dir 2
+    put_check_grouping dir 3
+}
+
+function test_max_grouping_tape() {
+    TAPES=$(get_tapes L6 3 | nodeset -e)
+    DRIVES=$(get_lto_drives 6 3)
+
+    $phobos tape add -t LTO6 ${TAPES}
+    $phobos drive add --unlock ${DRIVES}
+    $phobos tape format --unlock ${TAPES}
+
+    put_check_grouping tape 1
+    put_check_grouping tape 2
+    put_check_grouping tape 3
+}
+
+TEST_SETUP=setup
+
+TESTS=("test_max_grouping_dir")
+if [[ -w /dev/changer ]]; then
+    TESTS+=("test_max_grouping_tape")
+fi
+
+TEST_CLEANUP=cleanup

--- a/tests/externs/cli/test_fifo_max_write_per_grouping.test
+++ b/tests/externs/cli/test_fifo_max_write_per_grouping.test
@@ -42,12 +42,14 @@ function setup()
 
     setup_test_dirs
     setup_dummy_files 3 1k 1
-    DIRS=()
-    for i in `seq 0 2`; do
-        DIRS+=($(mktemp -d ${DIR_TEST}/dir_XXXX))
-        $phobos dir add ${DIRS[$i]}
-        $phobos dir format --unlock ${DIRS[$i]}
-    done
+    DIRS=(
+        $(mktemp -d ${DIR_TEST}/dir_XXXX)
+        $(mktemp -d ${DIR_TEST}/dir_XXXX)
+        $(mktemp -d ${DIR_TEST}/dir_XXXX)
+    )
+
+    $phobos dir add ${DIRS[@]}
+    $phobos dir format --unlock ${DIRS[@]}
 }
 
 function cleanup() {
@@ -111,13 +113,6 @@ function put_check_grouping() {
 }
 
 function test_max_grouping_dir() {
-    DIRS=()
-    for i in `seq 0 2`; do
-        DIRS+=($(mktemp -d ${DIR_TEST}/dir_XXXX))
-        $phobos dir add ${DIRS[$i]}
-        $phobos dir format --unlock ${DIRS[$i]}
-    done
-
     put_check_grouping dir 1
     put_check_grouping dir 2
     put_check_grouping dir 3


### PR DESCRIPTION
We add a configurable maximum of writes in parallel using the same grouping for one fifo scheduler. This allows to limit the number of media that are used in parallel to the same grouping.

If there is already as many current writes of the same grouping as the configured maximum, new writes of this grouping coming to the tail of the fifo queue are pushed back to the head. Other newer requests may be scheduled before the requeued ones. In addition of breaking the fifo order, this new behaviour could produce additional tapes movements because new requests could ask for new media that will remove current media of the targeted grouping of the requeued write before it comes back to the tail of the fifo queue.

That's why this new limit parameter has to be used carefully, until we develop a true "per grouping write scheduler", similar to the grouped read scheduler.

This patch is a first answer to the github issue #28 before we code a "per grouping write scheduler".
(https://github.com/phobos-storage/phobos/issues/28) .

Change-Id: I77406d162f3c5a3c34e95f7492f7087588539ed6