### PR TITLE
cli: add phobos extent list --orphan

### DIFF
--- a/src/admin/admin.c
+++ b/src/admin/admin.c
@@ -1686,50 +1686,66 @@ int phobos_admin_ping_tlc(const char *library, bool *library_is_up)
 }
 
 /**
- * Construct the medium string for the extent list filter.
- *
- * The caller must ensure medium_str is initialized before calling.
- *
- * \param[in,out]   medium_str      Empty medium string.
- * \param[in]       medium          Medium filter.
- */
-static void phobos_construct_medium(GString *medium_str, const char *medium)
-{
-    /**
-     * We prefered putting this line in a separate function to ease a
-     * possible future change that would allow for multiple medium selection.
-     */
-    g_string_append_printf(medium_str, "{\"DSS::EXT::medium_id\": \"%s\"}",
-                           medium);
-}
-
-static void phobos_construct_library(GString *library_str, const char *library)
-{
-    g_string_append_printf(library_str,
-                           "{\"DSS::EXT::medium_library\": \"%s\"}", library);
-}
-
-static void phobos_construct_library_medium(GString *lib_med_str,
-                                            const char *medium,
-                                            const char *library)
-{
-    g_string_append_printf(lib_med_str,
-                           "{\"$AND\": [{\"DSS::EXT::medium_id\": \"%s\"}, "
-                           "{\"DSS::EXT::medium_library\": \"%s\"}]}",
-                           medium, library);
-}
-/**
  * Construct the extent string for the extent list filter.
  *
  * The caller must ensure extent_str is initialized before calling.
  *
  * \param[in,out]   extent_str      Empty extent string.
+ * \param[in]       medium          Medium filter.
+ * \param[in]       library         Library filter.
+ * \param[in]       orphan          Orphan state filter.
+ */
+static void phobos_construct_extent(GString *extent_str, const char *medium,
+                                    const char *library, bool orphan)
+{
+    bool close_and = false;
+    bool library_is_valid;
+    bool medium_is_valid;
+    int count = 0;
+
+    medium_is_valid = (medium && strcmp(medium, ""));
+    library_is_valid = (library && strcmp(library, ""));
+
+    count += (medium_is_valid ? 1 : 0);
+    count += (library_is_valid ? 1 : 0);
+    count += (orphan ? 1 : 0);
+
+    if (count > 1) {
+        close_and = true;
+        g_string_append_printf(extent_str, "{\"$AND\":[");
+    }
+
+    if (medium_is_valid)
+        g_string_append_printf(extent_str,
+                               "{\"DSS::EXT::medium_id\": \"%s\"}%s",
+                                medium, --count != 0 ? "," : "");
+
+    if (library_is_valid)
+        g_string_append_printf(extent_str,
+                               "{\"DSS::EXT::medium_library\": \"%s\"}%s",
+                               library, --count != 0 ? "," : "");
+
+    if (orphan)
+        g_string_append_printf(extent_str,
+                               "{\"DSS::EXT::state\": \"%s\"}",
+                               extent_state2str(PHO_EXT_ST_ORPHAN));
+
+    if (close_and)
+        g_string_append_printf(extent_str, "]}");
+}
+
+/**
+ * Construct the object string for the extent list filter.
+ *
+ * The caller must ensure obj_str is initialized before calling.
+ *
+ * \param[in,out]   obj_str         Empty object string.
  * \param[in]       res             Ressource filter.
  * \param[in]       n_res           Number of requested resources.
  * \param[in]       is_pattern      True if search done using POSIX pattern.
  * \param[in]       copy_name       Copy name filter.
  */
-static void phobos_construct_extent(GString *extent_str, const char **res,
+static void phobos_construct_object(GString *obj_str, const char **res,
                                     int n_res, bool is_pattern,
                                     const char *copy_name)
 {
@@ -1738,17 +1754,17 @@ static void phobos_construct_extent(GString *extent_str, const char **res,
     int i;
 
     if (copy_name) {
-        g_string_append_printf(extent_str, "{\"$AND\" : [");
-        g_string_append_printf(extent_str,
+        g_string_append_printf(obj_str, "{\"$AND\" : [");
+        g_string_append_printf(obj_str,
                                "{\"DSS::COPY::copy_name\":\"%s\"}%s",
                                copy_name, n_res ? "," : "");
     }
 
     if (n_res > 1)
-        g_string_append_printf(extent_str, "{\"$OR\" : [");
+        g_string_append_printf(obj_str, "{\"$OR\" : [");
 
     for (i = 0; i < n_res; ++i)
-        g_string_append_printf(extent_str,
+        g_string_append_printf(obj_str,
                                "%s {\"DSS::OBJ::oid\":\"%s\"}%s %s",
                                res_prefix,
                                res[i],
@@ -1756,46 +1772,39 @@ static void phobos_construct_extent(GString *extent_str, const char **res,
                                (i + 1 != n_res) ? "," : "");
 
     if (n_res > 1)
-        g_string_append_printf(extent_str, "]}");
+        g_string_append_printf(obj_str, "]}");
 
     if (copy_name)
-        g_string_append_printf(extent_str, "]}");
+        g_string_append_printf(obj_str, "]}");
 }
 
 int phobos_admin_layout_list(struct admin_handle *adm, const char **res,
                              int n_res, bool is_pattern, const char *medium,
                              const char *library, const char *copy_name,
-                             struct layout_info **layouts,
+                             bool orphan, struct layout_info **layouts,
                              int *n_layouts, struct dss_sort *sort)
 {
-    struct dss_filter *lib_med_filter_ptr = NULL;
-    struct dss_filter *ext_filter_ptr = NULL;
-    struct dss_filter lib_med_filter;
-    struct dss_filter ext_filter;
-    bool library_is_valid;
-    bool medium_is_valid;
-    GString *lib_med_str;
+    struct dss_filter *extent_filter_ptr = NULL;
+    struct dss_filter *obj_filter_ptr = NULL;
+    struct dss_filter extent_filter;
+    struct dss_filter obj_filter;
     GString *extent_str;
+    GString *obj_str;
     int rc = 0;
 
-    lib_med_str = g_string_new(NULL);
     extent_str = g_string_new(NULL);
-    medium_is_valid = (medium && strcmp(medium, ""));
-    library_is_valid = (library && strcmp(library, ""));
+    obj_str = g_string_new(NULL);
 
-    if (medium_is_valid && !library_is_valid)
-        phobos_construct_medium(lib_med_str, medium);
-    else if (library_is_valid && !medium_is_valid)
-        phobos_construct_library(lib_med_str, library);
-    else if (library_is_valid && medium_is_valid)
-        phobos_construct_library_medium(lib_med_str, medium, library);
+    if (medium || library || orphan) {
+        phobos_construct_extent(extent_str, medium, library, orphan);
 
-    if (lib_med_str->len > 0) {
-        rc = dss_filter_build(&lib_med_filter, "%s", lib_med_str->str);
-        if (rc)
-            goto release_extent;
+        if (extent_str->len > 0) {
+            rc = dss_filter_build(&extent_filter, "%s", extent_str->str);
+            if (rc)
+                goto release_extent;
 
-        lib_med_filter_ptr = &lib_med_filter;
+            extent_filter_ptr = &extent_filter;
+        }
     }
 
     /**
@@ -1803,12 +1812,12 @@ int phobos_admin_layout_list(struct admin_handle *adm, const char **res,
      * each request.
      */
     if (n_res || copy_name) {
-        phobos_construct_extent(extent_str, res, n_res, is_pattern, copy_name);
-        rc = dss_filter_build(&ext_filter, "%s", extent_str->str);
+        phobos_construct_object(obj_str, res, n_res, is_pattern, copy_name);
+        rc = dss_filter_build(&obj_filter, "%s", obj_str->str);
         if (rc)
             goto release_extent;
 
-        ext_filter_ptr = &ext_filter;
+        obj_filter_ptr = &obj_filter;
     }
 
     /**
@@ -1816,17 +1825,17 @@ int phobos_admin_layout_list(struct admin_handle *adm, const char **res,
      * necessary, thus passing them as NULL to dss_full_layout_get ensures
      * the expected behaviour.
      */
-    rc = dss_full_layout_get(&adm->dss, ext_filter_ptr, lib_med_filter_ptr,
+    rc = dss_full_layout_get(&adm->dss, obj_filter_ptr, extent_filter_ptr,
                              layouts, n_layouts, sort);
     if (rc)
         pho_error(rc, "Cannot fetch layouts");
 
 release_extent:
-    g_string_free(lib_med_str, TRUE);
+    g_string_free(obj_str, TRUE);
     g_string_free(extent_str, TRUE);
 
-    dss_filter_free(lib_med_filter_ptr);
-    dss_filter_free(ext_filter_ptr);
+    dss_filter_free(extent_filter_ptr);
+    dss_filter_free(obj_filter_ptr);
 
     return rc;
 }

--- a/src/cli/phobos/cli/target/extent.py
+++ b/src/cli/phobos/cli/target/extent.py
@@ -58,6 +58,8 @@ class ExtentListOptHandler(ListOptHandler):
         parser.add_argument('-p', '--pattern', action='store_true',
                             help="filter using POSIX regexp instead of "
                                  "exact extent")
+        parser.add_argument('--orphan', action='store_true',
+                            help="list only extent that are orphan")
 
 
 class ExtentOptHandler(BaseResourceOptHandler):
@@ -79,6 +81,9 @@ class ExtentOptHandler(BaseResourceOptHandler):
 
         if self.params.get('copy_name'):
             kwargs['copy_name'] = self.params.get('copy_name')
+
+        if self.params.get('orphan'):
+            kwargs['orphan'] = self.params.get('orphan')
 
         kwargs = handle_sort_option(self.params, LayoutInfo(), self.logger,
                                     **kwargs)

--- a/src/cli/phobos/core/admin.py
+++ b/src/cli/phobos/core/admin.py
@@ -290,6 +290,7 @@ class Client: # pylint: disable=too-many-public-methods
         layouts = pointer(LayoutInfo())
         library_name = kwargs.get('library')
         copy_name = kwargs.get('copy_name')
+        orphan = kwargs.get('orphan')
 
         enc_medium = medium.encode('utf-8') if medium else None
         enc_library = library_name.encode('utf-8') if library_name else None
@@ -308,6 +309,7 @@ class Client: # pylint: disable=too-many-public-methods
                                                       enc_medium,
                                                       enc_library,
                                                       enc_copy_name,
+                                                      orphan,
                                                       byref(layouts),
                                                       byref(n_layouts),
                                                       sref)

--- a/src/include/phobos_admin.h
+++ b/src/include/phobos_admin.h
@@ -326,6 +326,7 @@ int phobos_admin_ping_tlc(const char *library, bool *library_is_up);
  * \param[in]       medium          Single medium filter.
  * \param[in]       library         Single library filter.
  * \param[in]       copy_name       Single copy name filter.
+ * \param[in]       orphan          Orphan state filter.
  * \param[out]      layouts         Retrieved layouts.
  * \param[out]      n_layouts       Number of retrieved items.
  *
@@ -337,7 +338,7 @@ int phobos_admin_ping_tlc(const char *library, bool *library_is_up);
 int phobos_admin_layout_list(struct admin_handle *adm, const char **res,
                              int n_res, bool is_pattern, const char *medium,
                              const char *library, const char *copy_name,
-                             struct layout_info **layouts,
+                             bool orphan, struct layout_info **layouts,
                              int *n_layouts, struct dss_sort *sort);
 
 /**

--- a/tests/externs/cli/test_extent_list.test
+++ b/tests/externs/cli/test_extent_list.test
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-#  All rights reserved (c) 2014-2024 CEA/DAM.
+#  All rights reserved (c) 2014-2025 CEA/DAM.
 #
 #  This file is part of Phobos.
 #
@@ -232,11 +232,48 @@ function test_extent_list_copy_name() {
     echo "$output" | grep "bob"
 }
 
+function test_extent_list_orphan() {
+    $phobos put -f dir /etc/hosts oid1-orphan
+    $phobos put -f dir /etc/hosts oid2-orphan
+
+    local output=$($valg_phobos extent list -f csv -o oid,state --orphan |
+                   tail -n +2 | wc -l)
+    if [[ $output -ne 0 ]]; then
+        error "There should be no extent, got $output"
+    fi
+
+    local extent_uuid=$($phobos extent list -o ext_uuid oid1-orphan)
+    extent_uuid=${extent_uuid#\[\'}
+    extent_uuid=${extent_uuid%\'\]}
+
+    $PSQL << EOF
+UPDATE extent SET state = 'orphan' WHERE extent_uuid='$extent_uuid';
+EOF
+
+    output=$($valg_phobos extent list -f csv -o oid,state --orphan |
+             tail -n +2)
+    local count=$(echo "$output" | wc -l)
+    if [[ $count -ne 1 ]]; then
+        error "There should be one extent, got $count"
+    fi
+
+    local oid=$(echo "$output" | cut -d',' -f1)
+    if [[ "$oid" != "oid1-orphan" ]]; then
+        error "It should be oid1-orphan, got $oid"
+    fi
+
+    local state=$(echo "$output" | cut -d',' -f2)
+    if [[ "$state" != "['orphan']" ]]; then
+        error "It should be orphan, got $state"
+    fi
+}
+
 TEST_SETUP=setup
 TESTS=("test_extent_list_degroup"
        "test_extent_list_pattern"
        "test_extent_list_copy_name"
-       "test_extent_list_dirs_lib")
+       "test_extent_list_dirs_lib"
+       "test_extent_list_orphan")
 
 if [[ -w /dev/changer ]]; then
     TESTS+=("test_extent_list_tapes_lib")

--- a/tests/externs/cli/test_extent_list.test
+++ b/tests/externs/cli/test_extent_list.test
@@ -239,7 +239,7 @@ function test_extent_list_orphan() {
     local output=$($valg_phobos extent list -f csv -o oid,state --orphan |
                    tail -n +2 | wc -l)
     if [[ $output -ne 0 ]]; then
-        error "There should be no extent, got $output"
+        error "There should be no orphan extent, got $output"
     fi
 
     local extent_uuid=$($phobos extent list -o ext_uuid oid1-orphan)
@@ -250,21 +250,14 @@ function test_extent_list_orphan() {
 UPDATE extent SET state = 'orphan' WHERE extent_uuid='$extent_uuid';
 EOF
 
-    output=$($valg_phobos extent list -f csv -o oid,state --orphan |
-             tail -n +2)
+    output=$($valg_phobos extent list --orphan)
     local count=$(echo "$output" | wc -l)
     if [[ $count -ne 1 ]]; then
         error "There should be one extent, got $count"
     fi
 
-    local oid=$(echo "$output" | cut -d',' -f1)
-    if [[ "$oid" != "oid1-orphan" ]]; then
+    if [[ "$output" != "oid1-orphan" ]]; then
         error "It should be oid1-orphan, got $oid"
-    fi
-
-    local state=$(echo "$output" | cut -d',' -f2)
-    if [[ "$state" != "['orphan']" ]]; then
-        error "It should be orphan, got $state"
     fi
 }
 


### PR DESCRIPTION
This pull request adds a new --orphan option to the phobos extent list command. When specified, only extents whose state is “orphan” will be shown. This change is linked to pull request #41.