### PR TITLE
admin: reuse tags from the source during repack

### DIFF
--- a/src/admin/admin.c
+++ b/src/admin/admin.c
@@ -1555,8 +1555,9 @@ int phobos_admin_repack(struct admin_handle *adm, const struct pho_id *source,
     if (rc)
         goto free_tags;
 
-    /* Prepare write allocation */
-    /* Use the same tags of the source medium */
+    /* Prepare write allocation
+     * Use the same tags as the source medium
+     */
     if (tags->count == 0)
         ptr_tags = &src_tags;
     /* Use no tags */
@@ -1570,8 +1571,6 @@ int phobos_admin_repack(struct admin_handle *adm, const struct pho_id *source,
                             &iod_target, &target);
     if (rc) {
         free(loc_source.root_path);
-        if (src_tags.count > 0)
-            string_array_free(&src_tags);
 
         _send_and_recv_release(adm, source, &iod_source, 3, NULL, NULL, 0, 0);
         goto free_tags;

--- a/src/admin/admin.c
+++ b/src/admin/admin.c
@@ -1463,9 +1463,10 @@ free_ext:
     return rc;
 }
 
-static int _retrieve_fstype_from_medium(struct admin_handle *adm,
-                                        const struct pho_id *medium,
-                                        enum fs_type *fstype)
+static int _retrieve_source_info(struct admin_handle *adm,
+                                 const struct pho_id *medium,
+                                 struct string_array *tags,
+                                 enum fs_type *fs_type)
 {
     struct dss_filter filter;
     struct media_info *media;
@@ -1486,16 +1487,18 @@ static int _retrieve_fstype_from_medium(struct admin_handle *adm,
     dss_filter_free(&filter);
     if (rc)
         LOG_RETURN(rc,
-                   "Failed to retrieve medium (family '%s', name '%s', library "
-                   "'%s') info from DSS", rsc_family2str(medium->family),
-                   medium->name, medium->library);
+                   "Failed to retrieve medium "FMT_PHO_ID" info from DSS",
+                   PHO_ID(*medium));
 
     if (count != 1) {
         dss_res_free(media, count);
         LOG_RETURN(-EINVAL, "Did not retrieve one medium, %d instead", count);
     }
 
-    *fstype = media->fs.type;
+    string_array_dup(tags, &media->tags);
+    if (fs_type)
+        *fs_type = media->fs.type;
+
     dss_res_free(media, count);
 
     return 0;
@@ -1507,10 +1510,13 @@ int phobos_admin_repack(struct admin_handle *adm, const struct pho_id *source,
     enum fs_type source_fs_type = PHO_FS_INVAL;
     struct pho_io_descr iod_source = {0};
     struct pho_io_descr iod_target = {0};
+    struct string_array empty_tags = {0};
     struct pho_ext_loc loc_source = {0};
     struct pho_ext_loc loc_target = {0};
     struct io_adapter_module *ioa = {0};
+    struct string_array *ptr_tags;
     struct extent *ext_res = NULL;
+    struct string_array src_tags;
     GArray *new_ext_uuids = NULL;
     int ext_cnt_done = 0;
     struct pho_id target;
@@ -1532,26 +1538,46 @@ int phobos_admin_repack(struct admin_handle *adm, const struct pho_id *source,
     if (rc)
         return rc;
 
+    rc = _retrieve_source_info(adm, source, &src_tags,
+                               source_fs_type == PHO_FS_INVAL ?
+                                  &source_fs_type : NULL);
+    if (rc)
+        LOG_GOTO(free_ext, rc,
+                 "Failed to retrieve info for "FMT_PHO_ID, PHO_ID(*source));
+
     total_size = _sum_extent_size(ext_res, ext_cnt);
     if (total_size == 0)
         goto format;
-
-    new_ext_uuids = g_array_new(FALSE, TRUE, sizeof(ext_res[0].uuid));
 
     /* Prepare read allocation */
     rc = _get_source_medium(adm, source, &loc_source, &iod_source, &ioa,
                             &source_fs_type);
     if (rc)
-        goto free_ext;
+        goto free_tags;
 
     /* Prepare write allocation */
-    rc = _get_target_medium(adm, source, total_size, tags, &loc_target,
+    /* Use the same tags of the source medium */
+    if (tags->count == 0)
+        ptr_tags = &src_tags;
+    /* Use no tags */
+    else if (tags->count == 1 && strcmp(tags->strings[0], "") == 0)
+        ptr_tags = &empty_tags;
+    /* Use the tags specified */
+    else
+        ptr_tags = tags;
+
+    rc = _get_target_medium(adm, source, total_size, ptr_tags, &loc_target,
                             &iod_target, &target);
     if (rc) {
         free(loc_source.root_path);
+        if (src_tags.count > 0)
+            string_array_free(&src_tags);
+
         _send_and_recv_release(adm, source, &iod_source, 3, NULL, NULL, 0, 0);
-        goto free_ext;
+        goto free_tags;
     }
+
+    new_ext_uuids = g_array_new(FALSE, TRUE, sizeof(ext_res[0].uuid));
 
     /* Copy loop */
     for (i = 0; i < ext_cnt; ++i, ++ext_cnt_done) {
@@ -1606,20 +1632,10 @@ int phobos_admin_repack(struct admin_handle *adm, const struct pho_id *source,
     new_ext_uuids = NULL;
 
 format:
-    if (source_fs_type == PHO_FS_INVAL) {
-        rc = _retrieve_fstype_from_medium(adm, source, &source_fs_type);
-        if (rc)
-            LOG_GOTO(free_ext, rc,
-                     "Failed to retrieve FS type for (family '%s', name '%s', "
-                     "library '%s')", rsc_family2str(source->family),
-                     source->name, source->library);
-    }
-
     rc = phobos_admin_format(adm, source, 1, 1, source_fs_type, true, true);
     if (rc)
         LOG_GOTO(free_ext, rc,
-                 "Failed to format (family '%s', name '%s', library '%s')",
-                 rsc_family2str(source->family), source->name, source->library);
+                 "Failed to format "FMT_PHO_ID, PHO_ID(*source));
 
     rc = _clean_database_following_format(adm, source);
 
@@ -1634,6 +1650,9 @@ free_ext:
             pho_error(rc, "Failed to update state of new extents to orphan");
 
     }
+
+free_tags:
+    string_array_free(&src_tags);
     dss_res_free(ext_res, ext_cnt);
 
     return rc;

--- a/src/cli/phobos/cli/target/tape.py
+++ b/src/cli/phobos/cli/target/tape.py
@@ -49,7 +49,10 @@ class TapeRepackOptHandler(ActionOptHandler):
         super(TapeRepackOptHandler, cls).add_options(parser)
         parser.add_argument('-T', '--tags', type=lambda t: t.split(','),
                             help='Only use a tape that contain this set of '
-                                 'tags (comma-separated: foo,bar)')
+                                 'tags (comma-separated: foo,bar).'
+                                 'If not specified, Phobos will use a tape '
+                                 'with the same tags as the repack tape. To '
+                                 'let Phobos choose any tape, use --tags "".')
         parser.add_argument('res', help='Tape to repack')
         parser.add_argument('--library',
                             help="Library containing the tape to repack")

--- a/tests/externs/cli/test_repack.test
+++ b/tests/externs/cli/test_repack.test
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-#  All rights reserved (c) 2014-2024 CEA/DAM.
+#  All rights reserved (c) 2014-2025 CEA/DAM.
 #
 #  This file is part of Phobos.
 #
@@ -32,16 +32,15 @@ test_dir=$(dirname $(readlink -e $0))
 function setup
 {
     setup_tables
-    invoke_tlc
+    invoke_daemons
     invoke_tlc_bis
-    invoke_lrs
 }
 
 function cleanup
 {
-    waive_lrs
-    waive_tlc
     waive_tlc_bis
+    waive_daemons
+    drain_all_drives
     drop_tables
     rm -f /tmp/oid-repack*
     rm -f /tmp/oid_bis-repack*
@@ -106,20 +105,24 @@ function tape_setup
     setup
 
     export drives="$(get_lto_drives 5 2)"
-    export media="$(get_tapes L5 3 | nodeset -e)"
+    export media="$(get_tapes L5 4 | nodeset -e)"
     export tape_bis="$(get_tapes_bis L6 1)"
     export drive_bis="$(get_lto_drives_bis 6 1)"
 
     export medium_origin="$(echo $media | cut -d' ' -f1)"
     export medium_alt="$(echo $media | cut -d' ' -f2)"
     export medium_other="$(echo $media | cut -d' ' -f3)"
+    export medium_origin_bis="$(echo $media | cut -d' ' -f4)"
 
     $phobos drive add --unlock $drives
     $phobos tape add -t lto5 -T origin $medium_origin
+    $phobos tape add -t lto5 -T origin $medium_origin_bis
     $phobos tape add -t lto5 -T alt $medium_alt
     $phobos tape add -t lto5 $medium_other
 
     $phobos tape format --unlock $media
+    # Lock it to prevent write on it
+    $phobos tape lock $medium_origin_bis
 
     if [[ ${bis} = "bis" ]]; then
         $phobos drive add --unlock --library library_bis $drive_bis
@@ -130,6 +133,8 @@ function tape_setup
     else
         obj_setup
     fi
+
+    $phobos tape unlock $medium_origin_bis
 }
 
 function tape_cleanup
@@ -152,12 +157,12 @@ function test_simple_repack
         error "repack should not have selected a used medium"
     fi
 
-    nb=$($phobos extent list --name $medium_other | wc -l)
+    nb=$($phobos extent list --name $medium_origin_bis | wc -l)
     if [ $nb -ne 3 ]; then
         error "repack should have copied 3 extents to the empty medium"
     fi
 
-    nb=$($phobos tape list -o stats.nb_obj $(echo $media | cut -d' ' -f3))
+    nb=$($phobos tape list -o stats.nb_obj $medium_origin_bis)
     if [ $nb -ne 3 ]; then
         error "tape stats should have said 3 extents were copied"
     fi
@@ -218,7 +223,7 @@ function test_raid1_repack
 {
     local family=$1
 
-    $phobos $family repack $medium_origin1
+    $phobos -vv $family repack $medium_origin1
 
     nb=$($phobos object list --deprecated-only | wc -l)
     if [ $nb -ne 0 ]; then
@@ -265,12 +270,15 @@ function test_dedup_repack_setup
 
     $phobos drive add --unlock $drives
     $phobos tape add -t lto5 -T origin $medium_origin
-    $phobos tape add -t lto5 $medium_other
+    $phobos tape add -t lto5 -T origin $medium_other
 
     $phobos tape format --unlock $media
+    $phobos tape lock $medium_other
 
     $phobos put -T origin /etc/hosts oid-1
     $phobos put -T origin /etc/hosts oid-2
+
+    $phobos tape unlock $medium_other
 
     object_uuid1=$($phobos object list -o uuid oid-1)
     extent_uuid1=$($phobos extent list --degroup -o ext_uuid oid-1)
@@ -321,11 +329,45 @@ function test_dedup_repack
         error "file oid-repack-dedup is not correctly retrieved"
 }
 
-function test_tagged_repack
+function test_no_tag_repack
 {
-    local family=$1
+    # Without tags, should repack on a tape with the same tags
+    $phobos tape lock $medium_origin_bis
+    $valg_phobos -vv tape repack $medium_origin &&
+        error "Repack should have failed"
 
-    $phobos $family repack -T alt $medium_origin
+    $phobos tape unlock $medium_origin_bis
+
+    $valg_phobos tape repack $medium_origin ||
+        error "Repack should have succeed"
+
+    nb=$($phobos extent list --name $medium_origin_bis | wc -l)
+    if [ $nb -ne 3 ]; then
+        error "repack should have copied 3 extents to the tagged medium"
+    fi
+
+    nb=$($phobos object list --deprecated-only | wc -l)
+    if [ $nb -ne 0 ]; then
+        error "repack should have deleted deprecated objects"
+    fi
+
+    obj_check
+
+    state=$($phobos tape list -o fs.status $medium_origin)
+    if [ "$state" != "empty" ]; then
+        error "repack should format source medium"
+    fi
+}
+
+function test_tags_repack
+{
+    $phobos tape lock $medium_alt
+    $valg_phobos tape repack -T alt $medium_origin &&
+        error "Repack should have failed"
+
+    $phobos tape unlock $medium_alt
+    $valg_phobos tape repack -T alt $medium_origin ||
+        error "Repack should have succeed"
 
     nb=$($phobos extent list --name $medium_alt | wc -l)
     if [ $nb -ne 3 ]; then
@@ -339,7 +381,41 @@ function test_tagged_repack
 
     obj_check
 
-    state=$($phobos $family list -o fs.status $medium_origin)
+    state=$($phobos tape list -o fs.status $medium_origin)
+    if [ "$state" != "empty" ]; then
+        error "repack should format source medium"
+    fi
+}
+
+function test_tags_empty_repack
+{
+    $phobos tape lock $medium_other
+    $phobos tape lock $medium_origin_bis
+    $phobos tape lock $medium_alt
+    $valg_phobos tape repack -T "" $medium_origin &&
+        error "Repack should have failed"
+
+    $phobos tape unlock $medium_other
+    $phobos tape unlock $medium_origin_bis
+    $phobos tape unlock $medium_alt
+    $valg_phobos tape repack -T "" $medium_origin ||
+        error "Repack should have succeed"
+
+    nb=$(($phobos extent list --name $medium_alt;
+          $phobos extent list --name $medium_other;
+          $phobos extent list --name $medium_origin_bis) | wc -l)
+    if [ $nb -ne 3 ]; then
+        error "repack should have copied 3 extents to one available medium"
+    fi
+
+    nb=$($phobos object list --deprecated-only | wc -l)
+    if [ $nb -ne 0 ]; then
+        error "repack should have deleted deprecated objects"
+    fi
+
+    obj_check
+
+    state=$($phobos tape list -o fs.status $medium_origin)
     if [ "$state" != "empty" ]; then
         error "repack should format source medium"
     fi
@@ -375,11 +451,10 @@ function test_simple_repack_library_bis
 
     obj_check_bis
 
-    # TODO WAITING availaibility of library option in media list
-    #state=$($phobos $family list --library library_bis -o fs.status $tape_bis)
-    #if [ "$state" != "empty" ]; then
-    #    error "repack should format source medium in library bis"
-    #fi
+    state=$($phobos tape list --library library_bis -o fs.status $tape_bis)
+    if [ "$state" != "empty" ]; then
+        error "repack should format source medium in library bis"
+    fi
 }
 
 if [[ ! -w /dev/changer ]]; then
@@ -387,11 +462,12 @@ if [[ ! -w /dev/changer ]]; then
 fi
 
 TEST_CLEANUP=cleanup
-TESTS=("tape_setup;test_simple_repack tape;tape_cleanup")
-TESTS+=("tape_setup;test_deprec_repack tape;tape_cleanup")
-TESTS+=("test_raid1_repack_setup;test_raid1_repack tape;tape_cleanup")
-TESTS+=("tape_setup;test_orphan_repack tape;tape_cleanup")
-TESTS+=("test_dedup_repack_setup;test_dedup_repack tape;tape_cleanup")
-TESTS+=("tape_setup;test_tagged_repack tape;tape_cleanup")
-TESTS+=("tape_setup bis;test_simple_repack_library_bis;tape_cleanup")
-
+TESTS=("tape_setup;test_simple_repack tape;tape_cleanup"
+       "tape_setup;test_deprec_repack tape;tape_cleanup"
+       "test_raid1_repack_setup;test_raid1_repack tape;tape_cleanup"
+       "tape_setup;test_orphan_repack tape;tape_cleanup"
+       "test_dedup_repack_setup;test_dedup_repack tape;tape_cleanup"
+        "tape_setup;test_no_tag_repack;tape_cleanup"
+       "tape_setup;test_tags_repack;tape_cleanup"
+       "tape_setup;test_tags_empty_repack;tape_cleanup"
+       "tape_setup bis;test_simple_repack_library_bis;tape_cleanup")

--- a/tests/externs/cli/test_repack.test
+++ b/tests/externs/cli/test_repack.test
@@ -147,6 +147,12 @@ function test_simple_repack
 {
     local family=$1
 
+    $phobos tape lock $medium_origin_bis
+    $valg_phobos tape repack $medium_origin &&
+        error "Repack should have failed"
+
+    $phobos tape unlock $medium_origin_bis
+
     # Make 'alt' medium not empty to prevent its selection for repack
     $phobos put -T alt /etc/hosts oid5
 
@@ -223,7 +229,7 @@ function test_raid1_repack
 {
     local family=$1
 
-    $phobos -vv $family repack $medium_origin1
+    $phobos $family repack $medium_origin1
 
     nb=$($phobos object list --deprecated-only | wc -l)
     if [ $nb -ne 0 ]; then
@@ -270,15 +276,14 @@ function test_dedup_repack_setup
 
     $phobos drive add --unlock $drives
     $phobos tape add -t lto5 -T origin $medium_origin
-    $phobos tape add -t lto5 -T origin $medium_other
 
-    $phobos tape format --unlock $media
-    $phobos tape lock $medium_other
+    $phobos tape format --unlock $medium_origin
 
     $phobos put -T origin /etc/hosts oid-1
     $phobos put -T origin /etc/hosts oid-2
 
-    $phobos tape unlock $medium_other
+    $phobos tape add -t lto5 -T origin $medium_other
+    $phobos tape format --unlock $medium_other
 
     object_uuid1=$($phobos object list -o uuid oid-1)
     extent_uuid1=$($phobos extent list --degroup -o ext_uuid oid-1)
@@ -327,36 +332,6 @@ function test_dedup_repack
 
     diff /etc/hosts /tmp/oid-repack-dedup ||
         error "file oid-repack-dedup is not correctly retrieved"
-}
-
-function test_no_tag_repack
-{
-    # Without tags, should repack on a tape with the same tags
-    $phobos tape lock $medium_origin_bis
-    $valg_phobos -vv tape repack $medium_origin &&
-        error "Repack should have failed"
-
-    $phobos tape unlock $medium_origin_bis
-
-    $valg_phobos tape repack $medium_origin ||
-        error "Repack should have succeed"
-
-    nb=$($phobos extent list --name $medium_origin_bis | wc -l)
-    if [ $nb -ne 3 ]; then
-        error "repack should have copied 3 extents to the tagged medium"
-    fi
-
-    nb=$($phobos object list --deprecated-only | wc -l)
-    if [ $nb -ne 0 ]; then
-        error "repack should have deleted deprecated objects"
-    fi
-
-    obj_check
-
-    state=$($phobos tape list -o fs.status $medium_origin)
-    if [ "$state" != "empty" ]; then
-        error "repack should format source medium"
-    fi
 }
 
 function test_tags_repack
@@ -467,7 +442,6 @@ TESTS=("tape_setup;test_simple_repack tape;tape_cleanup"
        "test_raid1_repack_setup;test_raid1_repack tape;tape_cleanup"
        "tape_setup;test_orphan_repack tape;tape_cleanup"
        "test_dedup_repack_setup;test_dedup_repack tape;tape_cleanup"
-        "tape_setup;test_no_tag_repack;tape_cleanup"
        "tape_setup;test_tags_repack;tape_cleanup"
        "tape_setup;test_tags_empty_repack;tape_cleanup"
        "tape_setup bis;test_simple_repack_library_bis;tape_cleanup")


### PR DESCRIPTION
This pull request adds support for reusing tags from the source medium by default. This means that if the --tags option is not specified, Phobos will search for another medium with the same tags as the source.

Also, if --tags "" is explicitly specified, Phobos will consider any available medium, restoring the previous behavior when the option was not used.

resolve: #44 


