### PR TITLE
lrs: prevent negative physical space free update

### DIFF
--- a/src/core/dss/dss.c
+++ b/src/core/dss/dss.c
@@ -468,6 +468,14 @@ int dss_media_update(struct dss_handle *handle, struct media_info *src_list,
             if (NB_OBJ_ADD & fields)
                 medium_info->stats.nb_obj += dst_list[i].stats.nb_obj;
 
+
+            /*
+             * DSS stats values must be positive values even if previous
+             * approximations compute negative values.
+             */
+            if (medium_info->stats.nb_obj < 0)
+                medium_info->stats.nb_obj = 0;
+
             if (LOGC_SPC_USED & fields)
                 medium_info->stats.logc_spc_used =
                     dst_list[i].stats.logc_spc_used;
@@ -476,13 +484,22 @@ int dss_media_update(struct dss_handle *handle, struct media_info *src_list,
                 medium_info->stats.logc_spc_used +=
                     dst_list[i].stats.logc_spc_used;
 
-            if (PHYS_SPC_USED & fields)
+            if (medium_info->stats.logc_spc_used < 0)
+                medium_info->stats.logc_spc_used = 0;
+
+            if (PHYS_SPC_USED & fields) {
                 medium_info->stats.phys_spc_used =
                     dst_list[i].stats.phys_spc_used;
+                if (medium_info->stats.phys_spc_used < 0)
+                    medium_info->stats.phys_spc_used = 0;
+            }
 
-            if (PHYS_SPC_FREE & fields)
+            if (PHYS_SPC_FREE & fields) {
                 medium_info->stats.phys_spc_free =
                     dst_list[i].stats.phys_spc_free;
+                if (medium_info->stats.phys_spc_free < 0)
+                    medium_info->stats.phys_spc_free = 0;
+            }
 
             dst_list[i].stats = medium_info->stats;
             dss_res_free(medium_info, 1);

--- a/src/lrs/lrs.c
+++ b/src/lrs/lrs.c
@@ -479,6 +479,23 @@ static int update_phys_spc_free(struct dss_handle *dss,
 {
     if (written_size > 0) {
         dss_media_info->stats.phys_spc_free -= written_size;
+        /*
+         * Written size could be overstated, especially when media have automatic
+         * compression.
+         *
+         * This value will be correctly updated at sync with ldm_fs_df input.
+         * Meanwhile, we set 0 instead of an inaccurate negative value.
+         */
+        if (dss_media_info->stats.phys_spc_free < 0) {
+            pho_debug("Update negative phys_spc_free %zd of medium "
+                      "(family '%s', name '%s', library '%s') is set to zero",
+                      dss_media_info->stats.phys_spc_free,
+                      rsc_family2str(dss_media_info->rsc.id.family),
+                      dss_media_info->rsc.id.name,
+                      dss_media_info->rsc.id.library);
+            dss_media_info->stats.phys_spc_free = 0;
+        }
+
         return dss_media_update(dss, dss_media_info, dss_media_info, 1,
                                 PHYS_SPC_FREE);
     }


### PR DESCRIPTION
Repack, with its huge amount of newly written extents, could try to update a negative physical space free at release. This is due to the fact that we ignore automatic compression that happens on magnetic tape. The correct value will be set by the statfs at sync. Meanwhile, we set the secure 0 value.

Negative value is not accepted by dss_media_get.

This patch fix the github issue #53 .