### PR TITLE
repack: order the extents to be copied by ctime

### DIFF
--- a/src/admin/admin.c
+++ b/src/admin/admin.c
@@ -1231,7 +1231,11 @@ static int _get_extents(struct admin_handle *adm,
     if (rc)
         LOG_RETURN(rc, "Failed to build filter for extent retrieval");
 
-    rc = dss_extent_get(&adm->dss, &filter, extents, count);
+    if (repack)
+        rc = dss_get_extents_order_by_ctime(&adm->dss, &filter, extents,
+                                            count);
+    else
+        rc = dss_extent_get(&adm->dss, &filter, extents, count);
     dss_filter_free(&filter);
     if (rc)
         LOG_RETURN(rc,

--- a/src/admin/admin.c
+++ b/src/admin/admin.c
@@ -1236,6 +1236,7 @@ static int _get_extents(struct admin_handle *adm,
                                             count);
     else
         rc = dss_extent_get(&adm->dss, &filter, extents, count);
+
     dss_filter_free(&filter);
     if (rc)
         LOG_RETURN(rc,

--- a/src/core/dss/wrapper.c
+++ b/src/core/dss/wrapper.c
@@ -946,3 +946,34 @@ int dss_check_and_take_lock(struct dss_handle *handle,
 
     return 0;
 }
+
+int dss_get_extents_order_by_ctime(struct dss_handle *handle,
+                                   const struct dss_filter *filter,
+                                   struct extent **extents, int *count)
+{
+    GString *request = g_string_new(NULL);
+    GString *clause = g_string_new(NULL);
+    int rc = 0;
+
+    if (filter) {
+        rc = clause_filter_convert(handle, clause, filter);
+        if (rc)
+            goto out;
+    }
+
+    g_string_append_printf(request,
+            "SELECT extent_uuid, size, offsetof, medium_family, state, "
+            "medium_id, medium_library, address, hash, info FROM layout "
+            "INNER JOIN extent USING (extent_uuid) INNER JOIN copy USING "
+            "(object_uuid, version, copy_name) %s ORDER BY creation_time;",
+            clause->str != NULL ? clause->str : "");
+
+    rc = dss_execute_generic_get(handle, DSS_EXTENT, request,
+                                 (void **) extents, count);
+
+out:
+    g_string_free(request, true);
+    g_string_free(clause, true);
+
+    return rc;
+}

--- a/src/core/dss/wrapper.c
+++ b/src/core/dss/wrapper.c
@@ -964,7 +964,7 @@ int dss_get_extents_order_by_ctime(struct dss_handle *handle,
     g_string_append_printf(request,
             "SELECT extent_uuid, size, offsetof, medium_family, state, "
             "medium_id, medium_library, address, hash, info FROM layout "
-            "INNER JOIN extent USING (extent_uuid) INNER JOIN copy USING "
+            "JOIN extent USING (extent_uuid) JOIN copy USING "
             "(object_uuid, version, copy_name) %s ORDER BY creation_time;",
             clause->str != NULL ? clause->str : "");
 

--- a/src/include/pho_dss_wrapper.h
+++ b/src/include/pho_dss_wrapper.h
@@ -339,4 +339,18 @@ int dss_check_and_take_lock(struct dss_handle *handle,
                             void *resource,
                             const char *hostname, int pid);
 
+/**
+ * Retrieve extents from DSS order by ctime.
+ *
+ * @param[in]   handle   DSS handle
+ * @param[in]   filter   Assembled DSS filtering criteria
+ * @param[out]  extents  List of retrieved extents
+ * @param[out]  count    Numver of extents in the list
+ *
+ * @return 0 or negative error code
+ */
+int dss_get_extents_order_by_ctime(struct dss_handle *handle,
+                                   const struct dss_filter *filter,
+                                   struct extent **extents, int *count);
+
 #endif

--- a/tests/externs/cli/test_repack.test
+++ b/tests/externs/cli/test_repack.test
@@ -456,33 +456,6 @@ EOF
            error "Wrong order, it's should be ${expected[$i]}"
         fi
     done
-
-    nb=$($phobos extent list --name $medium_alt | wc -l)
-    if [ $nb -ne 1 ]; then
-        error "repack should not have selected a used medium"
-    fi
-
-    nb=$($phobos extent list --name $medium_origin_bis | wc -l)
-    if [ $nb -ne 3 ]; then
-        error "repack should have copied 3 extents to the empty medium"
-    fi
-
-    nb=$($phobos tape list -o stats.nb_obj $medium_origin_bis)
-    if [ $nb -ne 3 ]; then
-        error "tape stats should have said 3 extents were copied"
-    fi
-
-    nb=$($phobos object list --deprecated-only | wc -l)
-    if [ $nb -ne 0 ]; then
-        error "repack should have deleted deprecated objects"
-    fi
-
-    obj_check
-
-    state=$($phobos $family list -o fs.status $medium_origin)
-    if [ "$state" != "empty" ]; then
-        error "repack should format source medium"
-    fi
 }
 
 if [[ ! -w /dev/changer ]]; then

--- a/tests/externs/cli/test_repack.test
+++ b/tests/externs/cli/test_repack.test
@@ -433,6 +433,58 @@ function test_simple_repack_library_bis
     fi
 }
 
+function test_repack_order_ctime
+{
+    local family=$1
+
+    # Make 'alt' medium not empty to prevent its selection for repack
+    $phobos put -T alt /etc/hosts oid5
+
+    local obj_uuid=$($phobos object list -o uuid oid-repack-1)
+    $PSQL << EOF
+UPDATE copy SET creation_time = now() WHERE object_uuid='$obj_uuid';
+EOF
+    $valg_phobos $family repack $medium_origin
+
+    local mount_point=$($phobos drive status -o mount_path | tail -n1)
+    local new_extents=($(find $mount_point -type f -printf "%T@ %f\n" | sort -n | cut -d ' ' -f2 | cut -d '.' -f1))
+
+    local expected=("oid-repack-3" "oid-repack-4" "oid-repack-1")
+
+    for i in 0 1 2; do
+        if [[ "${new_extents[$i]}" != "${expected[$i]}" ]]; then
+           error "Wrong order, it's should be ${expected[$i]}"
+        fi
+    done
+
+    nb=$($phobos extent list --name $medium_alt | wc -l)
+    if [ $nb -ne 1 ]; then
+        error "repack should not have selected a used medium"
+    fi
+
+    nb=$($phobos extent list --name $medium_origin_bis | wc -l)
+    if [ $nb -ne 3 ]; then
+        error "repack should have copied 3 extents to the empty medium"
+    fi
+
+    nb=$($phobos tape list -o stats.nb_obj $medium_origin_bis)
+    if [ $nb -ne 3 ]; then
+        error "tape stats should have said 3 extents were copied"
+    fi
+
+    nb=$($phobos object list --deprecated-only | wc -l)
+    if [ $nb -ne 0 ]; then
+        error "repack should have deleted deprecated objects"
+    fi
+
+    obj_check
+
+    state=$($phobos $family list -o fs.status $medium_origin)
+    if [ "$state" != "empty" ]; then
+        error "repack should format source medium"
+    fi
+}
+
 if [[ ! -w /dev/changer ]]; then
     skip "Library required for this test"
 fi
@@ -445,4 +497,5 @@ TESTS=("tape_setup;test_simple_repack tape;tape_cleanup"
        "test_dedup_repack_setup;test_dedup_repack tape;tape_cleanup"
        "tape_setup;test_tags_repack;tape_cleanup"
        "tape_setup;test_tags_empty_repack;tape_cleanup"
-       "tape_setup bis;test_simple_repack_library_bis;tape_cleanup")
+       "tape_setup bis;test_simple_repack_library_bis;tape_cleanup"
+       "tape_setup;test_repack_order_ctime tape;tape_cleanup")


### PR DESCRIPTION
This pull request orders the extents to be copied during repack according to their ctime. Ordering by ctime reduces tape workload, since all extents to be copied are generally placed sequentially on the tape.