### PR TITLE
locate: change asserts to proper checks

### DIFF
--- a/src/admin/import.c
+++ b/src/admin/import.c
@@ -283,7 +283,7 @@ static int _add_extent_to_dss(struct dss_handle *dss,
         LOG_RETURN(rc, "Could not get extent '%s'", lyt_insert->oid);
 
     if (layout_count > 1)
-        LOG_GOTO(lyt_info_get_free, rc = -ENOTSUP,
+        LOG_GOTO(lyt_info_get_free, rc = -ETOOMANYREFS,
                  "UUID '%s', version '%d' and copy_name '%s' should uniquely "
                  "identify a layout, found '%d' layouts matching",
                  lyt_insert->uuid, lyt_insert->version, lyt_insert->copy_name,
@@ -843,6 +843,13 @@ int update_copy_availability(struct admin_handle *adm, struct copy_info *copy)
     dss_filter_free(&filter);
     if (rc)
         return rc;
+
+    if (lyt_cnt > 1)
+        LOG_GOTO(end, rc = -ETOOMANYREFS,
+                 "UUID '%s', version '%d' and copy_name '%s' should uniquely "
+                 "identify a layout, found '%d' layouts matching",
+                 copy->object_uuid, copy->version, copy->copy_name,
+                 lyt_cnt);
 
     // Works like this in the current database version
     assert(lyt_cnt <= 1);

--- a/src/admin/import.c
+++ b/src/admin/import.c
@@ -851,9 +851,6 @@ int update_copy_availability(struct admin_handle *adm, struct copy_info *copy)
                  copy->object_uuid, copy->version, copy->copy_name,
                  lyt_cnt);
 
-    // Works like this in the current database version
-    assert(lyt_cnt <= 1);
-
     if (lyt_cnt == 0) {
         copy->copy_status = PHO_COPY_STATUS_INCOMPLETE;
         goto end;

--- a/src/core/dss/wrapper.c
+++ b/src/core/dss/wrapper.c
@@ -807,7 +807,14 @@ int dss_lazy_find_copy(struct dss_handle *handle, const char *uuid,
     if (rc)
         LOG_RETURN(rc, "Cannot fetch copy for objuuid:'%s'", uuid);
 
-    assert(copy_cnt >= 1);
+    if (copy_cnt == 0) {
+        pho_error(rc = -ENOENT,
+                  "Failed to find a copy of object with uuid '%s' and version '%d'",
+                  uuid, version);
+        LOG_RETURN(rc,
+                   "Object ('%s', '%d') is registered in the database but without any copy, you might want to delete it.",
+                   uuid, version);
+    }
 
     *copy = copy_info_dup(&copy_list[0]);
 

--- a/src/core/dss/wrapper.c
+++ b/src/core/dss/wrapper.c
@@ -807,14 +807,11 @@ int dss_lazy_find_copy(struct dss_handle *handle, const char *uuid,
     if (rc)
         LOG_RETURN(rc, "Cannot fetch copy for objuuid:'%s'", uuid);
 
-    if (copy_cnt == 0) {
-        pho_error(rc = -ENOENT,
-                  "Failed to find a copy of object with uuid '%s' and version '%d'",
-                  uuid, version);
-        LOG_RETURN(rc,
-                   "Object ('%s', '%d') is registered in the database but without any copy, you might want to delete it.",
+    if (copy_cnt == 0)
+        LOG_RETURN(rc = -ENOENT,
+                   "Failed to find a copy of object with uuid '%s' and version '%d'."
+                   "Since it is registered in the database without any copy, you might want to delete it.",
                    uuid, version);
-    }
 
     *copy = copy_info_dup(&copy_list[0]);
 

--- a/src/store/store.c
+++ b/src/store/store.c
@@ -2121,7 +2121,19 @@ int phobos_locate(const char *oid, const char *uuid, int version,
     if (rc)
         GOTO(clean, rc);
 
-    assert(cnt == 1);
+    if (cnt == 0) {
+        pho_error(rc = -ENOENT,
+                  "Failed to find layout of object with uuid '%s', version '%d' and copy '%s'",
+                  obj->uuid, obj->version, copy->copy_name);
+        LOG_GOTO(clean, rc,
+                 "Object ('%s', '%d', '%s') is registered in the database but without any layout, you might want to delete it.",
+                 obj->uuid, obj->version, copy->copy_name);
+    }
+
+    if (cnt > 1)
+        LOG_GOTO(clean, rc = -ETOOMANYREFS,
+                 "UUID '%s', version '%d' and copy_name '%s' should uniquely identify a layout, found '%d' layouts matching",
+                 obj->uuid, obj->version, copy->copy_name, cnt);
 
     /* locate media */
     rc = layout_locate(&dss, layout, focus_host, hostname, nb_new_lock);

--- a/tests/externs/api/test_locate.c
+++ b/tests/externs/api/test_locate.c
@@ -417,6 +417,8 @@ static void pl_enoent_with_only_object(void **state)
                        &hostname, NULL);
     assert_int_equal(rc, -ENOENT);
 
+    rc = dss_copy_delete(pl_state->dss, &copy, 1);
+    assert_int_equal(rc, 0);
     rc = dss_object_delete(pl_state->dss, &obj, 1);
     assert_int_equal(rc, 0);
 }


### PR DESCRIPTION
This patch changes the asserts done during a `phobos_locate` to proper checks. It is needed because there are cases where the DSS could contain an object but no associated copy or layout. This may occur for instance if a `put` process is killed before the end, leaving an incomplete object or copy in the database, which would cause assert failures during the `locate` as we assume there is a valid copy and layout for each object registered.

Change-Id: I9141aa7885f1c6279e2fcbffe05af5c301b4c723