### PR TITLE
lrs: fix dev_picker if lock_expirancy is non-null

### DIFF
--- a/src/lrs/io_schedulers/fifo.c
+++ b/src/lrs/io_schedulers/fifo.c
@@ -320,8 +320,9 @@ static int find_read_device(struct io_scheduler *io_sched,
                                 medium->rsc.id.name, medium->rsc.id.library,
                                 &sched_ready);
     if (!*dev) {
-        *dev = dev_picker(io_sched->devices, PHO_DEV_OP_ST_UNSPEC,
-                          medium->rsc.id.library, NULL,
+        *dev = dev_picker(io_sched->devices,
+                          io_sched->io_sched_hdl->lock_handle->dss,
+                          PHO_DEV_OP_ST_UNSPEC, medium->rsc.id.library, NULL,
                           select_empty_loaded_mount, 0, &NO_STRING, medium,
                           false, false, NULL);
 
@@ -383,7 +384,9 @@ static int find_write_device(struct io_scheduler *io_sched,
 search_again:
     need_new_grouping = false;
     /* 1a) is there a mounted filesystem with enough room? */
-    *dev = dev_picker(io_sched->devices, PHO_DEV_OP_ST_MOUNTED, wreq->library,
+    *dev = dev_picker(io_sched->devices,
+                      io_sched->io_sched_hdl->lock_handle->dss,
+                      PHO_DEV_OP_ST_MOUNTED, wreq->library,
                       targeted_grouping, dev_select_policy, size, &tags, NULL,
                       true, wreq->media[index]->empty_medium,
                       &one_drive_available);
@@ -393,7 +396,9 @@ search_again:
         return 0;
 
     /* 1b) is there a loaded media with enough room? */
-    *dev = dev_picker(io_sched->devices, PHO_DEV_OP_ST_LOADED, wreq->library,
+    *dev = dev_picker(io_sched->devices,
+                      io_sched->io_sched_hdl->lock_handle->dss,
+                      PHO_DEV_OP_ST_LOADED, wreq->library,
                       targeted_grouping, dev_select_policy, size, &tags, NULL,
                       true, wreq->media[index]->empty_medium,
                       &one_drive_available);
@@ -435,7 +440,9 @@ search_again:
     }
 
 find_device:
-    *dev = dev_picker(io_sched->devices, PHO_DEV_OP_ST_UNSPEC, wreq->library,
+    *dev = dev_picker(io_sched->devices,
+                      io_sched->io_sched_hdl->lock_handle->dss,
+                      PHO_DEV_OP_ST_UNSPEC, wreq->library,
                       targeted_grouping, select_empty_loaded_mount, 0,
                       &NO_STRING, *medium, true, false, NULL);
     if (*dev)
@@ -464,7 +471,9 @@ static int find_format_device(struct io_scheduler *io_sched,
     *dev = search_in_use_medium(io_sched->io_sched_hdl->global_device_list,
                                 med_id->name, med_id->library, &sched_ready);
     if (!*dev) {
-        *dev = dev_picker(io_sched->devices, PHO_DEV_OP_ST_UNSPEC,
+        *dev = dev_picker(io_sched->devices,
+                          io_sched->io_sched_hdl->lock_handle->dss,
+                          PHO_DEV_OP_ST_UNSPEC,
                           med_id->library, NULL, select_empty_loaded_mount,
                           0, &NO_STRING, reqc->params.format.medium_to_format,
                           false, false, NULL);

--- a/src/lrs/lrs_sched.c
+++ b/src/lrs/lrs_sched.c
@@ -1317,19 +1317,32 @@ static bool medium_is_write_compatible(struct media_info *medium,
     return true;
 }
 
-static bool check_locate_expirancy(struct media_info *medium,
+static bool check_locate_expirancy(struct dss_handle *handle,
+                                   struct media_info *medium,
                                    int lock_expirancy)
 {
     struct timespec expire;
+    struct pho_lock lock;
+    int rc;
 
-    expire.tv_nsec = medium->lock.last_locate.tv_usec * 1000 +
+    rc = dss_lock_status(handle, DSS_MEDIA, medium, 1, &lock);
+    if (rc) {
+        pho_warn("Failed to retrieve status for lock expirancy of "
+                 FMT_PHO_ID", will consider it expired",
+                 PHO_ID(medium->rsc.id));
+        return false;
+    }
+
+    expire.tv_nsec = lock.last_locate.tv_usec * 1000 +
         (lock_expirancy % 1000) * 1000000;
-    expire.tv_sec = medium->lock.last_locate.tv_sec + lock_expirancy / 1000;
+    expire.tv_sec = lock.last_locate.tv_sec + lock_expirancy / 1000;
 
     if (expire.tv_nsec >= 1000000000) {
         expire.tv_nsec %= 1000000000;
         expire.tv_sec += 1;
     }
+
+    free(lock.hostname);
 
     return !is_past(expire);
 }
@@ -1368,6 +1381,7 @@ typedef int (*device_select_func_t)(size_t required_size,
  *                                  (ignored if NULL)
  */
 struct lrs_dev *dev_picker(GPtrArray *devices,
+                           struct dss_handle *dss,
                            enum dev_op_status op_st,
                            const char *library,
                            const char *grouping,
@@ -1404,16 +1418,12 @@ struct lrs_dev *dev_picker(GPtrArray *devices,
         }
 
         if (lock_expirancy != 0 && itr->ld_dss_media_info) {
-            struct media_info *medium = lrs_medium_update(
-                &itr->ld_dss_media_info->rsc.id);
 
-            if (check_locate_expirancy(medium, lock_expirancy)) {
-                lrs_medium_release(medium);
+            if (check_locate_expirancy(dss, itr->ld_dss_media_info, lock_expirancy)) {
                 pho_debug("Skipping device '%s' with reserved medium",
                           itr->ld_dev_path);
                 goto unlock_continue;
             }
-            lrs_medium_release(medium);
         }
 
         if (dev_is_failed(itr)) {

--- a/src/lrs/lrs_sched.h
+++ b/src/lrs/lrs_sched.h
@@ -409,6 +409,7 @@ int select_first_fit(size_t required_size,
                      struct lrs_dev **dev_selected);
 
 struct lrs_dev *dev_picker(GPtrArray *devices,
+                           struct dss_handle *dss,
                            enum dev_op_status op_st,
                            const char *library,
                            const char *grouping,

--- a/tests/externs/cli/test_locate.test
+++ b/tests/externs/cli/test_locate.test
@@ -225,6 +225,26 @@ function test_last_locate_timestamp
         error "Format should have waited for locate expirancy"
 }
 
+function test_put_with_lock_expirancy
+{
+    local drive=$(get_lto_drives 5 1)
+    $phobos drive add --unlock $drive
+
+    local tapes=( $(get_tapes L5 1 | nodeset -e) )
+    $phobos tape add --type lto5 ${tapes[@]}
+    $phobos tape format --unlock ${tapes[0]}
+
+    waive_lrs
+
+    export PHOBOS_LRS_locate_lock_expirancy=5000
+
+    invoke_lrs
+
+    local oid=$(generate_prefix_id)
+    $phobos put /etc/hosts $oid ||
+        error "Error while putting $oid"
+}
+
 function test_locate_compatibility
 {
     local N_TAPES=2
@@ -490,6 +510,9 @@ if [[ -w /dev/changer ]]; then
 #             tape_cleanup")
     TESTS+=("tape_init_setup; \
              test_last_locate_timestamp; \
+             tape_cleanup");
+    TESTS+=("tape_init_setup; \
+             test_put_with_lock_expirancy; \
              tape_cleanup");
     TESTS+=("tape_init_setup; \
              test_locate_compatibility; \

--- a/tests/interns/test_lrs_scheduling.c
+++ b/tests/interns/test_lrs_scheduling.c
@@ -118,7 +118,7 @@ static void dev_picker_no_device(void **data)
     bool one_device_available;
     struct lrs_dev *dev;
 
-    dev = dev_picker(devices, PHO_DEV_OP_ST_UNSPEC, NULL, NULL,
+    dev = dev_picker(devices, NULL, PHO_DEV_OP_ST_UNSPEC, NULL, NULL,
                      select_empty_loaded_mount, 0, &NO_STRING, NULL, false,
                      false, &one_device_available);
     assert_false(one_device_available);
@@ -137,7 +137,7 @@ static void dev_picker_one_available_device(void **data)
     create_device(&device, "test", LTO5_MODEL, NULL);
     gptr_array_from_list(devices, &device, 1, sizeof(device));
 
-    dev = dev_picker(devices, PHO_DEV_OP_ST_UNSPEC, NULL, NULL,
+    dev = dev_picker(devices, NULL, PHO_DEV_OP_ST_UNSPEC, NULL, NULL,
                      select_empty_loaded_mount, 0, &NO_STRING, NULL, false,
                      false, &one_device_available);
     assert_true(one_device_available);
@@ -160,7 +160,7 @@ static void dev_picker_one_booked_device(void **data)
 
     device.ld_ongoing_io = true;
 
-    dev = dev_picker(devices, PHO_DEV_OP_ST_UNSPEC, NULL, NULL,
+    dev = dev_picker(devices, NULL, PHO_DEV_OP_ST_UNSPEC, NULL, NULL,
                      select_empty_loaded_mount, 0, &NO_STRING, NULL, false,
                      false, &one_device_available);
     assert_false(one_device_available);
@@ -184,7 +184,7 @@ static void dev_picker_one_booked_device_one_available(void **data)
 
     device[0].ld_ongoing_io = true;
 
-    dev = dev_picker(devices, PHO_DEV_OP_ST_UNSPEC, NULL, NULL,
+    dev = dev_picker(devices, NULL, PHO_DEV_OP_ST_UNSPEC, NULL, NULL,
                      select_empty_loaded_mount, 0, &NO_STRING, NULL, false,
                      false, &one_device_available);
     assert_true(one_device_available);
@@ -192,7 +192,7 @@ static void dev_picker_one_booked_device_one_available(void **data)
     assert_string_equal(dev->ld_dev_path, "test2");
 
     dev->ld_ongoing_scheduled = true;
-    dev = dev_picker(devices, PHO_DEV_OP_ST_UNSPEC, NULL, NULL,
+    dev = dev_picker(devices, NULL, PHO_DEV_OP_ST_UNSPEC, NULL, NULL,
                      select_empty_loaded_mount, 0, &NO_STRING, NULL, false,
                      false, &one_device_available);
     assert_false(one_device_available);
@@ -216,7 +216,7 @@ static void dev_picker_search_mounted(void **data)
 
     gptr_array_from_list(devices, &device, 2, sizeof(device[0]));
 
-    dev = dev_picker(devices, PHO_DEV_OP_ST_MOUNTED, NULL, NULL,
+    dev = dev_picker(devices, NULL, PHO_DEV_OP_ST_MOUNTED, NULL, NULL,
                      select_empty_loaded_mount, 0, &NO_STRING, NULL, false,
                      false, &one_device_available);
     assert_true(one_device_available);
@@ -227,7 +227,7 @@ static void dev_picker_search_mounted(void **data)
 
     device[0].ld_ongoing_io = true;
 
-    dev = dev_picker(devices, PHO_DEV_OP_ST_MOUNTED, NULL, NULL,
+    dev = dev_picker(devices, NULL, PHO_DEV_OP_ST_MOUNTED, NULL, NULL,
                      select_empty_loaded_mount, 0, &NO_STRING, NULL, false,
                      false, &one_device_available);
     assert_true(one_device_available);
@@ -236,7 +236,7 @@ static void dev_picker_search_mounted(void **data)
 
     device[0].ld_ongoing_io = false;
     dev->ld_ongoing_scheduled = true;
-    dev = dev_picker(devices, PHO_DEV_OP_ST_MOUNTED, NULL, NULL,
+    dev = dev_picker(devices, NULL, PHO_DEV_OP_ST_MOUNTED, NULL, NULL,
                      select_empty_loaded_mount, 0, &NO_STRING, NULL, false,
                      false, &one_device_available);
     assert_true(one_device_available);
@@ -260,7 +260,7 @@ static void dev_picker_search_loaded(void **data)
 
     gptr_array_from_list(devices, &device, 2, sizeof(device[0]));
 
-    dev = dev_picker(devices, PHO_DEV_OP_ST_LOADED, NULL, NULL,
+    dev = dev_picker(devices, NULL, PHO_DEV_OP_ST_LOADED, NULL, NULL,
                      select_empty_loaded_mount, 0, &NO_STRING, NULL, false,
                      false, &one_device_available);
     assert_true(one_device_available);
@@ -271,7 +271,7 @@ static void dev_picker_search_loaded(void **data)
 
     device[0].ld_ongoing_io = true;
 
-    dev = dev_picker(devices, PHO_DEV_OP_ST_LOADED, NULL, NULL,
+    dev = dev_picker(devices, NULL, PHO_DEV_OP_ST_LOADED, NULL, NULL,
                      select_empty_loaded_mount, 0, &NO_STRING, NULL, false,
                      false, &one_device_available);
     assert_true(one_device_available);
@@ -279,7 +279,7 @@ static void dev_picker_search_loaded(void **data)
 
     load_medium(&device[0], &medium);
 
-    dev = dev_picker(devices, PHO_DEV_OP_ST_LOADED, NULL, NULL,
+    dev = dev_picker(devices, NULL, PHO_DEV_OP_ST_LOADED, NULL, NULL,
                      select_empty_loaded_mount, 0, &NO_STRING, NULL, false,
                      false, &one_device_available);
     assert_true(one_device_available);
@@ -287,7 +287,7 @@ static void dev_picker_search_loaded(void **data)
 
     device[0].ld_ongoing_io = false;
 
-    dev = dev_picker(devices, PHO_DEV_OP_ST_LOADED, NULL, NULL,
+    dev = dev_picker(devices, NULL, PHO_DEV_OP_ST_LOADED, NULL, NULL,
                      select_empty_loaded_mount, 0, &NO_STRING, NULL, false,
                      false, &one_device_available);
     assert_true(one_device_available);
@@ -321,7 +321,7 @@ static void dev_picker_available_space(void **data)
 
     gptr_array_from_list(devices, &device, 2, sizeof(device[0]));
 
-    dev = dev_picker(devices, PHO_DEV_OP_ST_MOUNTED, NULL, NULL,
+    dev = dev_picker(devices, NULL, PHO_DEV_OP_ST_MOUNTED, NULL, NULL,
                      select_first_fit, 200, &NO_STRING, NULL, true, false,
                      &one_device_available);
     assert_true(one_device_available);
@@ -329,7 +329,7 @@ static void dev_picker_available_space(void **data)
 
     medium_set_size(&medium[0], 300);
 
-    dev = dev_picker(devices, PHO_DEV_OP_ST_MOUNTED, NULL, NULL,
+    dev = dev_picker(devices, NULL, PHO_DEV_OP_ST_MOUNTED, NULL, NULL,
                      select_first_fit, 200, &NO_STRING, NULL, true, false,
                      &one_device_available);
     assert_true(one_device_available);
@@ -337,7 +337,7 @@ static void dev_picker_available_space(void **data)
     assert_string_equal(dev->ld_dev_path, "test1");
 
     dev->ld_ongoing_scheduled = true;
-    dev = dev_picker(devices, PHO_DEV_OP_ST_MOUNTED, NULL, NULL,
+    dev = dev_picker(devices, NULL, PHO_DEV_OP_ST_MOUNTED, NULL, NULL,
                      select_first_fit, 200, &NO_STRING, NULL, true, false,
                      &one_device_available);
     assert_true(one_device_available);
@@ -369,7 +369,7 @@ static void dev_picker_flags(void **data)
 
     device[0].ld_ongoing_io = true;
     device[1].ld_dss_media_info->flags.put = false;
-    dev = dev_picker(devices, PHO_DEV_OP_ST_MOUNTED, NULL, NULL,
+    dev = dev_picker(devices, NULL, PHO_DEV_OP_ST_MOUNTED, NULL, NULL,
                      select_first_fit, 0, &NO_STRING, NULL, true, false,
                      &one_device_available);
     assert_true(one_device_available);
@@ -377,7 +377,7 @@ static void dev_picker_flags(void **data)
 
     device[1].ld_dss_media_info->flags.put = true;
     device[1].ld_dss_media_info->fs.status = PHO_FS_STATUS_FULL;
-    dev = dev_picker(devices, PHO_DEV_OP_ST_MOUNTED, NULL, NULL,
+    dev = dev_picker(devices, NULL, PHO_DEV_OP_ST_MOUNTED, NULL, NULL,
                      select_first_fit, 0, &NO_STRING, NULL, true, false,
                      &one_device_available);
     assert_true(one_device_available);


### PR DESCRIPTION
Fixes #64

When scheduling a write allocation, the medium cache was badly managed, causing medium references to be removed during the allocation, thus preventing the medium to be retrieved for the release.

Also, the behavior was not optimal, as the algorithm did not consider last_locate timestamp if they happened after the cache load of medium info.

As a quick fix, we avoid using the medium cache, and check the value of last_locate timestamp directly in the DSS.

Further optimization can be implemented:
* in case the lock expirancy is set:
  * check for the last_locate timestamp in the medium cache
  * if expired:
    * check for the last_locate in the DSS
    * if last_locate is not different, lock is expired
    * if last_locate is different, update medium cache and check the expirancy

A test is added to verify the put succeeds even if a lock expirancy is set.