### PR TITLE
dss: remove extent uuid select in dss_insert_layout

### DIFF
--- a/src/core/dss/layout.c
+++ b/src/core/dss/layout.c
@@ -117,9 +117,8 @@ static int layout_insert_query(PGconn *conn, void *void_layout, int item_cnt,
                 request,
                 "((select object_uuid from object where oid = '%s'),"
                 " (select version from object where oid = '%s'),"
-                " (select extent_uuid from extent where address = '%s'),"
-                " %d, '%s')",
-                layout->oid, layout->oid, extent->address.buff,
+                " '%s', %d, '%s')",
+                layout->oid, layout->oid, extent->uuid,
                 extent->layout_idx, layout->copy_name
             );
 


### PR DESCRIPTION
We remove the layout scalability issue over the number of extent and the lack of index on address extent field.

The extent uuid select from its address is simply removed because the extent uuid is already known into the inserted layout.

This commit solves the github issue #63
(https://github.com/phobos-storage/phobos/issues/63)

Change-Id: I85e1485cdfb6e9bac9df44af3723dbbd589bd118
Signed-off-by: Patrice LUCAS <patrice.lucas@ayudata.fr>