### PR TITLE
dss: remove object uuid/version select in dss_insert_layout

### DIFF
--- a/src/admin/import.c
+++ b/src/admin/import.c
@@ -572,6 +572,8 @@ static int _import_file_to_dss(struct admin_handle *adm, int fd,
         LOG_RETURN(rc, "Could not add object to DSS");
 
     lyt_to_insert.oid = obj_to_insert.oid;
+    lyt_to_insert.uuid = obj_to_insert.uuid;
+    lyt_to_insert.version = obj_to_insert.version;
 
     rc = _add_extent_to_dss(&adm->dss, &lyt_to_insert, &ext_to_insert);
     if (rc)

--- a/src/core/dss/layout.c
+++ b/src/core/dss/layout.c
@@ -114,11 +114,8 @@ static int layout_insert_query(PGconn *conn, void *void_layout, int item_cnt,
             struct extent *extent = &layout->extents[j];
 
             g_string_append_printf(
-                request,
-                "((select object_uuid from object where oid = '%s'),"
-                " (select version from object where oid = '%s'),"
-                " '%s', %d, '%s')",
-                layout->oid, layout->oid, extent->uuid,
+                request, "('%s', %d, '%s', %d, '%s')",
+                layout->uuid, layout->version, extent->uuid,
                 extent->layout_idx, layout->copy_name
             );
 
@@ -143,10 +140,9 @@ static int layout_insert_query(PGconn *conn, void *void_layout, int item_cnt,
         g_string_append_printf(
             request,
             "UPDATE copy SET lyt_info = '%s' WHERE "
-            "object_uuid = (SELECT object_uuid FROM object WHERE oid = '%s') "
-            "AND version = (SELECT version FROM object WHERE oid = '%s') AND "
-            "copy_name = '%s';",
-            layout_description, layout->oid, layout->oid, layout->copy_name
+            "object_uuid = '%s' AND version = %d AND copy_name = '%s';",
+            layout_description, layout->uuid, layout->version,
+            layout->copy_name
         );
 
         free(layout_description);

--- a/src/store/store.c
+++ b/src/store/store.c
@@ -1331,6 +1331,9 @@ static int store_end_encoder_xfer(struct phobos_handle *pho,
             LOG_RETURN(rc, "Error while saving extents for objid: '%s'",
                        xfer->xd_targets[i].xt_objid);
 
+        encoder->dest_layout[i].uuid = xfer->xd_targets[i].xt_objuuid;
+        encoder->dest_layout[i].version = xfer->xd_targets[i].xt_version;
+
         rc = dss_layout_insert(&pho->dss, &encoder->dest_layout[i], 1);
         if (rc) {
             pho_error(rc, "Error while saving layout for objid: '%s'",


### PR DESCRIPTION
We remove the layout scalability issue over the number of object.

The object uuid/version select is simply removed because the object uuid and version is already known into the inserted layout.

This commit solves the github issue #63.
(https://github.com/phobos-storage/phobos/issues/63)